### PR TITLE
Update markets data to top 300 liquidity pools by reserves

### DIFF
--- a/src/dex-lists/markets.json
+++ b/src/dex-lists/markets.json
@@ -1,75 +1,23 @@
 [
   {
-    "name": "USDC.e / BOG",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xb09fe1613fe03e7361319d2a43edc17422f36b09",
-      "name": "Bogged Finance",
-      "symbol": "BOG"
-    }
-  },
-  {
-    "name": "Genesis / MIM",
-    "token0": {
-      "id": "0x1cc9cb8d0cc686e326893112ea19aa54dea00e2f",
-      "name": "Genesis Node",
-      "symbol": "Genesis"
-    },
-    "token1": {
-      "id": "0xa7b349a9a6595f0e5c7a80a6237ae7dc8ab43b88",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    }
-  },
-  {
-    "name": "JLP / JLP",
-    "token0": {
-      "id": "0x781655d802670bba3c89aebaaea59d3182fd755d",
-      "name": "Joe LP Token",
-      "symbol": "JLP"
-    },
-    "token1": {
-      "id": "0xa56d382c5aa9774d4eb98f1500670d3049fede9b",
-      "name": "Joe LP Token",
-      "symbol": "JLP"
-    }
-  },
-  {
-    "name": "LiPOGE / LiPOGE",
-    "token0": {
-      "id": "0x168c14b83c959778b6b8c4e4fa0c20af8df23e61",
-      "name": "iLiPoge Coin",
-      "symbol": "LiPOGE"
-    },
-    "token1": {
-      "id": "0xd9e8ae66782529b3fc9157af2b6fa137bea46e5d",
-      "name": "iLiPogeCoin",
-      "symbol": "LiPOGE"
-    }
-  },
-  {
-    "name": "JLP / JLP",
-    "token0": {
-      "id": "0x781655d802670bba3c89aebaaea59d3182fd755d",
-      "name": "Joe LP Token",
-      "symbol": "JLP"
-    },
-    "token1": {
-      "id": "0xbca892e5f463af9a27d571cc620cf3ebd998e276",
-      "name": "Joe LP Token",
-      "symbol": "JLP"
-    }
-  },
-  {
     "name": "AVAX / USDC",
     "token0": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "USDC.e / USDC",
+    "token0": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
     },
     "token1": {
       "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
@@ -91,42 +39,16 @@
     }
   },
   {
-    "name": "USDC.e / USDC",
+    "name": "USDt / AVAX",
     "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "BTC.b / AVAX",
-    "token0": {
-      "id": "0x152b9d0fdc40c096757f570a51e494bd4b943e50",
-      "name": "Bitcoin",
-      "symbol": "BTC.b"
+      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "name": "TetherToken",
+      "symbol": "USDt"
     },
     "token1": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "XETA / USDt",
-    "token0": {
-      "id": "0x31c994ac062c1970c086260bc61babb708643fac",
-      "name": "XANA",
-      "symbol": "XETA"
-    },
-    "token1": {
-      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
-      "name": "TetherToken",
-      "symbol": "USDt"
     }
   },
   {
@@ -143,29 +65,16 @@
     }
   },
   {
-    "name": "BDF / AVAX",
+    "name": "BTC.b / AVAX",
     "token0": {
-      "id": "0x60c0b0c3b97c4c1b5c74995cd3e6deebc2c55c78",
-      "name": "Bandung Financial",
-      "symbol": "BDF"
+      "id": "0x152b9d0fdc40c096757f570a51e494bd4b943e50",
+      "name": "Bitcoin",
+      "symbol": "BTC.b"
     },
     "token1": {
-      "id": "0x9b908fc861cee312255cb91a5f3d1ecb8f2d1772",
-      "name": "Wrapped AVAX",
-      "symbol": "WAVAX"
-    }
-  },
-  {
-    "name": "DD / CC",
-    "token0": {
-      "id": "0x206bc2ec94820aa54a4ed2be57249c2400f69631",
-      "name": "DD",
-      "symbol": "DD"
-    },
-    "token1": {
-      "id": "0x289c60a6df2f74afbb6dda88b53515a0c021a55f",
-      "name": "CC",
-      "symbol": "CC"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
     }
   },
   {
@@ -182,29 +91,16 @@
     }
   },
   {
-    "name": "USDt / AVAX",
+    "name": "sAVAX / AVAX",
     "token0": {
-      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
-      "name": "TetherToken",
-      "symbol": "USDt"
+      "id": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
+      "name": "Staked AVAX",
+      "symbol": "sAVAX"
     },
     "token1": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "MIM / JKL",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0x31d27a3e10839e61cfac5125e5c7b2d42503159f",
-      "name": "Jackal",
-      "symbol": "JKL"
     }
   },
   {
@@ -221,94 +117,16 @@
     }
   },
   {
-    "name": "sAVAX / AVAX",
+    "name": "EGG / AVAX",
     "token0": {
-      "id": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
-      "name": "Staked AVAX",
-      "symbol": "sAVAX"
+      "id": "0x7761e2338b35bceb6bda6ce477ef012bde7ae611",
+      "name": "chikn egg",
+      "symbol": "EGG"
     },
     "token1": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "Victorinox / AVAX",
-    "token0": {
-      "id": "0x366c02225c7afa52fd591f8816810ab707301871",
-      "name": "Victorinox Metaverse",
-      "symbol": "Victorinox"
-    },
-    "token1": {
-      "id": "0x86124f2a9fddd6badf5b2e8c5f8e101b78a16cfb",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "FLIX / AVAX",
-    "token0": {
-      "id": "0x9e9d3e99230c3bb4fa7efaa8d92be807a03cf2b4",
-      "name": "FLIX Token",
-      "symbol": "FLIX"
-    },
-    "token1": {
-      "id": "0xf5c09ee197d1e393c6cf37f4852b562fac0566da",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "NXUSD / WXT",
-    "token0": {
-      "id": "0xf14f4ce569cb3679e99d5059909e23b07bd2f387",
-      "name": "NXUSD",
-      "symbol": "NXUSD"
-    },
-    "token1": {
-      "id": "0xfcde4a87b8b6fa58326bb462882f1778158b02f1",
-      "name": "Wirex Token",
-      "symbol": "WXT"
-    }
-  },
-  {
-    "name": "WLRS / USDC.e",
-    "token0": {
-      "id": "0x395908aeb53d33a9b8ac35e148e9805d34a555d3",
-      "name": "frozenwalrus.finance",
-      "symbol": "WLRS"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "GMX / AVAX",
-    "token0": {
-      "id": "0x62edc0692bd897d2295872a9ffcac5425011c661",
-      "name": "GMX",
-      "symbol": "GMX"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDt / RUX",
-    "token0": {
-      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
-      "name": "TetherToken",
-      "symbol": "USDt"
-    },
-    "token1": {
-      "id": "0xa1afcc973d44ce1c65a21d9e644cb82489d26503",
-      "name": "RunBlox Token",
-      "symbol": "RUX"
     }
   },
   {
@@ -325,180 +143,11 @@
     }
   },
   {
-    "name": "sAVANET / AVANET",
+    "name": "GMX / AVAX",
     "token0": {
-      "id": "0x0c40f5d254bf89499198a38f058b376d895a0c9a",
-      "name": "StakedAVANET",
-      "symbol": "sAVANET"
-    },
-    "token1": {
-      "id": "0x246a08a58549e14d0fcb24d7e9227661ede807a8",
-      "name": "AvangerNews",
-      "symbol": "AVANET"
-    }
-  },
-  {
-    "name": "LiPOGE / USDT",
-    "token0": {
-      "id": "0x168c14b83c959778b6b8c4e4fa0c20af8df23e61",
-      "name": "iLiPoge Coin",
-      "symbol": "LiPOGE"
-    },
-    "token1": {
-      "id": "0xb91411de29ffcd75c3c816cfb1a8e24b13c86f4a",
-      "name": "TetherToken",
-      "symbol": "USDT"
-    }
-  },
-  {
-    "name": "WBTC.e / AVAX",
-    "token0": {
-      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
-      "name": "Wrapped BTC",
-      "symbol": "WBTC.e"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "THOR / AVAX",
-    "token0": {
-      "id": "0x8f47416cae600bccf9530e9f3aeaa06bdd1caa79",
-      "name": "THOR v2",
-      "symbol": "THOR"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDt / OWL",
-    "token0": {
-      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
-      "name": "TetherToken",
-      "symbol": "USDt"
-    },
-    "token1": {
-      "id": "0xab547a8dc764408ce9dea41bdf689aeeb349da12",
-      "name": "Owl Token",
-      "symbol": "OWL"
-    }
-  },
-  {
-    "name": "MIM / GRAPE",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0x5541d83efad1f281571b343977648b75d95cdac2",
-      "name": "Grape Finance",
-      "symbol": "GRAPE"
-    }
-  },
-  {
-    "name": "MIM / AVAX",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "MIM / GMA",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0x19cfd1a6b1cd236b542b561ed26b32d697e5a77f",
-      "name": "ENIGM",
-      "symbol": "GMA"
-    }
-  },
-  {
-    "name": "AVAX / KOO",
-    "token0": {
-      "id": "0x8e07269b6426f3d331c32d4b2ff609cfb4214ae1",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xf0eab3c65adfa7a1cf898817bdaa92052c2b7bdb",
-      "name": "Morning Always Comes",
-      "symbol": "KOO"
-    }
-  },
-  {
-    "name": "MIM / SKULL",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0x84a8297720fe27c71ffccfa3f685e4d9fc377afc",
-      "name": "Skull Finance",
-      "symbol": "SKULL"
-    }
-  },
-  {
-    "name": "PTP / AVAX",
-    "token0": {
-      "id": "0x22d4002028f537599be9f666d1c4fa138522f9c8",
-      "name": "Platypus",
-      "symbol": "PTP"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "JOE / USDC",
-    "token0": {
-      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
-      "name": "JoeToken",
-      "symbol": "JOE"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "USDC.e / WSHARE",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xe6d1afea0b76c8f51024683dd27fa446ddaf34b6",
-      "name": "Frozen Walrus Share",
-      "symbol": "WSHARE"
-    }
-  },
-  {
-    "name": "EGG / AVAX",
-    "token0": {
-      "id": "0x7761e2338b35bceb6bda6ce477ef012bde7ae611",
-      "name": "chikn egg",
-      "symbol": "EGG"
+      "id": "0x62edc0692bd897d2295872a9ffcac5425011c661",
+      "name": "GMX",
+      "symbol": "GMX"
     },
     "token1": {
       "id": "AVAX",
@@ -520,19 +169,6 @@
     }
   },
   {
-    "name": "WETH / USDC.e",
-    "token0": {
-      "id": "0x8b82a291f83ca07af22120aba21632088fc92931",
-      "name": "Wrapped Ether (Wormhole)",
-      "symbol": "WETH"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
     "name": "USDt / USDT.e",
     "token0": {
       "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
@@ -546,263 +182,16 @@
     }
   },
   {
-    "name": "AVAX / FIRE",
+    "name": "THOR / AVAX",
     "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xfcc6ce74f4cd7edef0c5429bb99d38a3608043a5",
-      "name": "FIRE",
-      "symbol": "FIRE"
-    }
-  },
-  {
-    "name": "UMAGA / AVAX",
-    "token0": {
-      "id": "0x495318dd72d0803c328d8a473ade0e3e6fe6feb9",
-      "name": "UltraMAGA",
-      "symbol": "UMAGA"
-    },
-    "token1": {
-      "id": "0xc545da6510834f46dd2f46e843206bf8a73f0673",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "BBB / AAA",
-    "token0": {
-      "id": "0xaf55626a06e8d48f70b6b58b0806765274e5ab46",
-      "name": "BBB",
-      "symbol": "BBB"
-    },
-    "token1": {
-      "id": "0xfc32516c6df1d346b56c4e477125a5d4a0ca56a2",
-      "name": "AAA",
-      "symbol": "AAA"
-    }
-  },
-  {
-    "name": "SKY / WAVX",
-    "token0": {
-      "id": "0x641e3862ec51eaff9368e39279f46db2a9aa5c47",
-      "name": "SKY",
-      "symbol": "SKY"
-    },
-    "token1": {
-      "id": "0xe3766695083db4c6155a69b1aead09b165535f23",
-      "name": "WAVX",
-      "symbol": "WAVX"
-    }
-  },
-  {
-    "name": "BNB / AVAX",
-    "token0": {
-      "id": "0x264c1383ea520f73dd837f915ef3a732e204a493",
-      "name": "Binance",
-      "symbol": "BNB"
+      "id": "0x8f47416cae600bccf9530e9f3aeaa06bdd1caa79",
+      "name": "THOR v2",
+      "symbol": "THOR"
     },
     "token1": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "LINK.e / AVAX",
-    "token0": {
-      "id": "0x5947bb275c521040051d82396192181b413227a3",
-      "name": "Chainlink Token",
-      "symbol": "LINK.e"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDC.e / SOL",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xfe6b19286885a4f7f55adad09c3cd1f906d2478f",
-      "name": "Wrapped SOL (Wormhole)",
-      "symbol": "SOL"
-    }
-  },
-  {
-    "name": "AVAX / DAI.e",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-      "name": "Dai Stablecoin",
-      "symbol": "DAI.e"
-    }
-  },
-  {
-    "name": "bAVAX / USDC.e",
-    "token0": {
-      "id": "0x4f1437a43500b7863c614528e6a15b220904010b",
-      "name": "bAVAX",
-      "symbol": "bAVAX"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "Hitech / DROP",
-    "token0": {
-      "id": "0x856d6d0cabf1adc2ab746cdcb7dda70f71793a25",
-      "name": "Hitech Network",
-      "symbol": "Hitech"
-    },
-    "token1": {
-      "id": "0xe7774a7904b4fc7f360660c6cfafa1d75ef6a90e",
-      "name": "DROP",
-      "symbol": "DROP"
-    }
-  },
-  {
-    "name": "VTX / AVAX",
-    "token0": {
-      "id": "0x5817d4f0b62a59b17f75207da1848c2ce75e7af4",
-      "name": "Vector",
-      "symbol": "VTX"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDC.e / WMATIC",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xf2f13f0b7008ab2fa4a2418f4ccc3684e49d20eb",
-      "name": "Wrapped Matic (Wormhole)",
-      "symbol": "WMATIC"
-    }
-  },
-  {
-    "name": "PLAYMATES / AVAX",
-    "token0": {
-      "id": "0x490bf3abcab1fb5c88533d850f2a8d6d38298465",
-      "name": "Playmates",
-      "symbol": "PLAYMATES"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "DAI.e / VOLT",
-    "token0": {
-      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-      "name": "Dai Stablecoin",
-      "symbol": "DAI.e"
-    },
-    "token1": {
-      "id": "0xf5ee578505f4d876fef288dfd9fd5e15e9ea1318",
-      "name": "Asgardian Aereus",
-      "symbol": "VOLT"
-    }
-  },
-  {
-    "name": "JOE / USDC.e",
-    "token0": {
-      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
-      "name": "JoeToken",
-      "symbol": "JOE"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "SMRTr / AVAX",
-    "token0": {
-      "id": "0x6d923f688c7ff287dc3a5943caeefc994f97b290",
-      "name": "SmarterCoin",
-      "symbol": "SMRTr"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "ZOO / AVAX",
-    "token0": {
-      "id": "0x1b88d7ad51626044ec62ef9803ea264da4442f32",
-      "name": "ZooToken",
-      "symbol": "ZOO"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "gOHM / AVAX",
-    "token0": {
-      "id": "0x321e7092a180bb43555132ec53aaa65a5bf84251",
-      "name": "Governance OHM",
-      "symbol": "gOHM"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "TRUSD / USDa",
-    "token0": {
-      "id": "0x2a385dfeab87ace4f5f64523932e4c6cec51bbd3",
-      "name": "TRUSD Stable Dollar",
-      "symbol": "TRUSD"
-    },
-    "token1": {
-      "id": "0x8ba03ce31f71c6733b0764ce82f3c68d4f6173fa",
-      "name": "USDa Stable Dollar",
-      "symbol": "USDa"
-    }
-  },
-  {
-    "name": "AVAX / RISE",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xc17c30e98541188614df99239cabd40280810ca3",
-      "name": "EverRise",
-      "symbol": "RISE"
     }
   },
   {
@@ -811,97 +200,6 @@
       "id": "0x83a283641c6b4df383bcddf807193284c84c5342",
       "name": "VaporNodes",
       "symbol": "VPND"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / FIEF",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xea068fba19ce95f12d252ad8cb2939225c4ea02d",
-      "name": "Fief",
-      "symbol": "FIEF"
-    }
-  },
-  {
-    "name": "EVO / AVAX",
-    "token0": {
-      "id": "0x42006ab57701251b580bdfc24778c43c9ff589a1",
-      "name": "EVO",
-      "symbol": "EVO"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "YETI / AVAX",
-    "token0": {
-      "id": "0x77777777777d4554c39223c354a05825b2e8faa3",
-      "name": "Yeti Finance",
-      "symbol": "YETI"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDC.e / OT / qiUSDC / 28DEC2023",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xfffe5fc3e511ce11df20684aec435a3e2b7d8136",
-      "name": "OT Benqi USDC 28DEC2023",
-      "symbol": "OT / qiUSDC / 28DEC2023"
-    }
-  },
-  {
-    "name": "MU / MUG",
-    "token0": {
-      "id": "0xd036414fa2bcbb802691491e323bff1348c5f4ba",
-      "name": "Mu Coin",
-      "symbol": "MU"
-    },
-    "token1": {
-      "id": "0xf7ed17f0fb2b7c9d3ddbc9f0679b2e1098993e81",
-      "name": "Mu Gold",
-      "symbol": "MUG"
-    }
-  },
-  {
-    "name": "AVAX / XAVA",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd1c3f94de7e5b45fa4edbba472491a9f4b166fc4",
-      "name": "Avalaunch",
-      "symbol": "XAVA"
-    }
-  },
-  {
-    "name": "ASTRO / AVAX",
-    "token0": {
-      "id": "0x6d2f5dbf3a7396fce32cfe406aef7a8aff812fbb",
-      "name": "100 Days Ventures  /  v1.1",
-      "symbol": "ASTRO"
     },
     "token1": {
       "id": "AVAX",
@@ -923,16 +221,159 @@
     }
   },
   {
-    "name": "MIM / WINE",
+    "name": "MIM / AVAX",
     "token0": {
       "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
       "name": "Magic Internet Money",
       "symbol": "MIM"
     },
     "token1": {
-      "id": "0xc55036b5348cfb45a932481744645985010d3a44",
-      "name": "Wine Shares",
-      "symbol": "WINE"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "JOE / USDC",
+    "token0": {
+      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
+      "name": "JoeToken",
+      "symbol": "JOE"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "VALI / USDC",
+    "token0": {
+      "id": "0x13031535e6f95076e0a36bc86e8aa64af3ba6961",
+      "name": "ValiFi Token",
+      "symbol": "VALI"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "PTP / AVAX",
+    "token0": {
+      "id": "0x22d4002028f537599be9f666d1c4fa138522f9c8",
+      "name": "Platypus",
+      "symbol": "PTP"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "VTX / AVAX",
+    "token0": {
+      "id": "0x5817d4f0b62a59b17f75207da1848c2ce75e7af4",
+      "name": "Vector",
+      "symbol": "VTX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DAI.e / VOLT",
+    "token0": {
+      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI.e"
+    },
+    "token1": {
+      "id": "0xf5ee578505f4d876fef288dfd9fd5e15e9ea1318",
+      "name": "Asgardian Aereus",
+      "symbol": "VOLT"
+    }
+  },
+  {
+    "name": "WBTC.e / AVAX",
+    "token0": {
+      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
+      "name": "Wrapped BTC",
+      "symbol": "WBTC.e"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / FIRE",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfcc6ce74f4cd7edef0c5429bb99d38a3608043a5",
+      "name": "FIRE",
+      "symbol": "FIRE"
+    }
+  },
+  {
+    "name": "MIM / GRAPE",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x5541d83efad1f281571b343977648b75d95cdac2",
+      "name": "Grape Finance",
+      "symbol": "GRAPE"
+    }
+  },
+  {
+    "name": "ZOO / AVAX",
+    "token0": {
+      "id": "0x1b88d7ad51626044ec62ef9803ea264da4442f32",
+      "name": "ZooToken",
+      "symbol": "ZOO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "LINK.e / AVAX",
+    "token0": {
+      "id": "0x5947bb275c521040051d82396192181b413227a3",
+      "name": "Chainlink Token",
+      "symbol": "LINK.e"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / DAI.e",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI.e"
     }
   },
   {
@@ -949,11 +390,50 @@
     }
   },
   {
-    "name": "pAVAX / AVAX",
+    "name": "AVAX / RISE",
     "token0": {
-      "id": "0x6ca558bd3eab53da1b25ab97916dd14bf6cfee4e",
-      "name": "pAVAX",
-      "symbol": "pAVAX"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc17c30e98541188614df99239cabd40280810ca3",
+      "name": "EverRise",
+      "symbol": "RISE"
+    }
+  },
+  {
+    "name": "MIM / SKULL",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x84a8297720fe27c71ffccfa3f685e4d9fc377afc",
+      "name": "Skull Finance",
+      "symbol": "SKULL"
+    }
+  },
+  {
+    "name": "USDC / yyAVAX",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+      "name": "YieldYak gAVAX",
+      "symbol": "yyAVAX"
+    }
+  },
+  {
+    "name": "gOHM / AVAX",
+    "token0": {
+      "id": "0x321e7092a180bb43555132ec53aaa65a5bf84251",
+      "name": "Governance OHM",
+      "symbol": "gOHM"
     },
     "token1": {
       "id": "AVAX",
@@ -962,16 +442,68 @@
     }
   },
   {
-    "name": "USDC.e / SDT",
+    "name": "EVO / AVAX",
     "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
+      "id": "0x42006ab57701251b580bdfc24778c43c9ff589a1",
+      "name": "EVO",
+      "symbol": "EVO"
     },
     "token1": {
-      "id": "0xccbf7c451f81752f7d2237f2c18c371e6e089e69",
-      "name": "Stake DAO Token",
-      "symbol": "SDT"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "USDC / BFG",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xfd538ca3f58dc309da55b11f007ff53fb4602876",
+      "name": "BattleForGiostone",
+      "symbol": "BFG"
+    }
+  },
+  {
+    "name": "AVAX / PENDLE",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfb98b335551a418cd0737375a2ea0ded62ea213b",
+      "name": "Pendle",
+      "symbol": "PENDLE"
+    }
+  },
+  {
+    "name": "AVAX / OBX",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xccf719c44e2c36e919335692e89d22cf13d6aaeb",
+      "name": "OpenBlox Token",
+      "symbol": "OBX"
+    }
+  },
+  {
+    "name": "AVAX / XAVA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd1c3f94de7e5b45fa4edbba472491a9f4b166fc4",
+      "name": "Avalaunch",
+      "symbol": "XAVA"
     }
   },
   {
@@ -988,16 +520,55 @@
     }
   },
   {
-    "name": "AVAX / PENDLE",
+    "name": "YETI / AVAX",
     "token0": {
+      "id": "0x77777777777d4554c39223c354a05825b2e8faa3",
+      "name": "Yeti Finance",
+      "symbol": "YETI"
+    },
+    "token1": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SMRTr / AVAX",
+    "token0": {
+      "id": "0x6d923f688c7ff287dc3a5943caeefc994f97b290",
+      "name": "SmarterCoin",
+      "symbol": "SMRTr"
     },
     "token1": {
-      "id": "0xfb98b335551a418cd0737375a2ea0ded62ea213b",
-      "name": "Pendle",
-      "symbol": "PENDLE"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / LF",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x5684a087c739a2e845f4aaaabf4fbd261edc2be8",
+      "name": "Life",
+      "symbol": "LF"
+    }
+  },
+  {
+    "name": "MIM / WINE",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xc55036b5348cfb45a932481744645985010d3a44",
+      "name": "Wine Shares",
+      "symbol": "WINE"
     }
   },
   {
@@ -1027,271 +598,11 @@
     }
   },
   {
-    "name": "AVAX / ECD",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xeb8343d5284caec921f035207ca94db6baaacbcd",
-      "name": "Echidna Token",
-      "symbol": "ECD"
-    }
-  },
-  {
-    "name": "JOE / USDT.e",
-    "token0": {
-      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
-      "name": "JoeToken",
-      "symbol": "JOE"
-    },
-    "token1": {
-      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
-      "name": "Tether USD",
-      "symbol": "USDT.e"
-    }
-  },
-  {
-    "name": "MIM / ASND",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0xfd0c58f03c83d6960bb9dbfd45076d78df2f095d",
-      "name": "Ascend",
-      "symbol": "ASND"
-    }
-  },
-  {
-    "name": "QI / AVAX",
-    "token0": {
-      "id": "0xa56f9a54880afbc30cf29bb66d2d9adcdcaeadd6",
-      "name": "Qi Dao Protocol",
-      "symbol": "QI"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / GMT",
-    "token0": {
-      "id": "0x0ef6b314c985dbda2c2611550a705a0a85ee4955",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0x60737f22cdffaef1746e082a2a1940f0421fab58",
-      "name": "Green Metaverse Token",
-      "symbol": "GMT"
-    }
-  },
-  {
-    "name": "AVAX / FRAX",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
-      "name": "Frax",
-      "symbol": "FRAX"
-    }
-  },
-  {
-    "name": "USDC / MEAD",
-    "token0": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    },
-    "token1": {
-      "id": "0xd21cdca47fa45a0a51eec030e27af390ab3aa489",
-      "name": "Mead",
-      "symbol": "MEAD"
-    }
-  },
-  {
-    "name": "DEG / AVAX",
-    "token0": {
-      "id": "0x9f285507ea5b4f33822ca7abb5ec8953ce37a645",
-      "name": "DegisToken",
-      "symbol": "DEG"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "CRA / AVAX",
-    "token0": {
-      "id": "0xa32608e873f9ddef944b24798db69d80bbb4d1ed",
-      "name": "CRA",
-      "symbol": "CRA"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "LIQR / AVAX",
-    "token0": {
-      "id": "0x33333ee26a7d02e41c33828b42fb1e0889143477",
-      "name": "LIQR",
-      "symbol": "LIQR"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
     "name": "NEWO / AVAX",
     "token0": {
       "id": "0x4bfc90322dd638f81f034517359bd447f8e0235a",
       "name": "New Order",
       "symbol": "NEWO"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "xPTP / PTP",
-    "token0": {
-      "id": "0x060556209e507d30f2167a101bfc6d256ed2f3e1",
-      "name": "xPTP",
-      "symbol": "xPTP"
-    },
-    "token1": {
-      "id": "0x22d4002028f537599be9f666d1c4fa138522f9c8",
-      "name": "Platypus",
-      "symbol": "PTP"
-    }
-  },
-  {
-    "name": "USDC.e / USDT.e",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
-      "name": "Tether USD",
-      "symbol": "USDT.e"
-    }
-  },
-  {
-    "name": "MAGIC / COSMIC",
-    "token0": {
-      "id": "0x9a8e0217cd870783c3f2317985c57bf570969153",
-      "name": "Magic",
-      "symbol": "MAGIC"
-    },
-    "token1": {
-      "id": "0xe48c74833ce6f18a8e54f73f1d02b8e9f9ff8caa",
-      "name": "Cosmic",
-      "symbol": "COSMIC"
-    }
-  },
-  {
-    "name": "WET / AVAX",
-    "token0": {
-      "id": "0xb1466d4cf0dcfc0bcddcf3500f473cdacb88b56d",
-      "name": "Weble Ecosystem Token",
-      "symbol": "WET"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "CMSN / AVAX",
-    "token0": {
-      "id": "0x2e1a7a2889154cded22f4ce8c4d1cc6dc4a58452",
-      "name": "The Commission",
-      "symbol": "CMSN"
-    },
-    "token1": {
-      "id": "0xed8a46ffc1835ff196b17487d8e9383a1e7c4753",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / IME",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xf891214fdcf9cdaa5fdc42369ee4f27f226adad6",
-      "name": "Imperium Empires Token",
-      "symbol": "IME"
-    }
-  },
-  {
-    "name": "ORBIT / AVAX",
-    "token0": {
-      "id": "0x340990358ae38008181b6db6156d9021a2d425da",
-      "name": "Europa Token",
-      "symbol": "ORBIT"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "WLRS / GRAPE",
-    "token0": {
-      "id": "0x395908aeb53d33a9b8ac35e148e9805d34a555d3",
-      "name": "frozenwalrus.finance",
-      "symbol": "WLRS"
-    },
-    "token1": {
-      "id": "0x5541d83efad1f281571b343977648b75d95cdac2",
-      "name": "Grape Finance",
-      "symbol": "GRAPE"
-    }
-  },
-  {
-    "name": "OT / JLP / 28DEC2023 / PENDLE",
-    "token0": {
-      "id": "0xabced2a62fd308bd1b98085c13df74b685140c0b",
-      "name": "OT Joe LP Token 28DEC2023",
-      "symbol": "OT / JLP / 28DEC2023"
-    },
-    "token1": {
-      "id": "0xfb98b335551a418cd0737375a2ea0ded62ea213b",
-      "name": "Pendle",
-      "symbol": "PENDLE"
-    }
-  },
-  {
-    "name": "$ALPHA / AVAX",
-    "token0": {
-      "id": "0x325a98f258a5732c7b06555603f6af5bc1c17f0a",
-      "name": "$ALPHA",
-      "symbol": "$ALPHA"
     },
     "token1": {
       "id": "AVAX",
@@ -1313,635 +624,11 @@
     }
   },
   {
-    "name": "MIM / LF",
+    "name": "BNB / AVAX",
     "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0x5684a087c739a2e845f4aaaabf4fbd261edc2be8",
-      "name": "Life",
-      "symbol": "LF"
-    }
-  },
-  {
-    "name": "SNCT / AVAX",
-    "token0": {
-      "id": "0x2905d6d6957983d9ed73bc019ff2782c39dd7a49",
-      "name": "Snake City Token",
-      "symbol": "SNCT"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "JOE / zJoe",
-    "token0": {
-      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
-      "name": "JoeToken",
-      "symbol": "JOE"
-    },
-    "token1": {
-      "id": "0x769bfeb9faacd6eb2746979a8dd0b7e9920ac2a4",
-      "name": "zJoe",
-      "symbol": "zJoe"
-    }
-  },
-  {
-    "name": "WBTC.e / USDC.e",
-    "token0": {
-      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
-      "name": "Wrapped BTC",
-      "symbol": "WBTC.e"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "gOHM / FRAX",
-    "token0": {
-      "id": "0x321e7092a180bb43555132ec53aaa65a5bf84251",
-      "name": "Governance OHM",
-      "symbol": "gOHM"
-    },
-    "token1": {
-      "id": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
-      "name": "Frax",
-      "symbol": "FRAX"
-    }
-  },
-  {
-    "name": "USDC.e / MU",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xd036414fa2bcbb802691491e323bff1348c5f4ba",
-      "name": "Mu Coin",
-      "symbol": "MU"
-    }
-  },
-  {
-    "name": "BDSCI1 / APE / X",
-    "token0": {
-      "id": "0x88e3850000ef6e56dfc7475b1a4b2214063eedb8",
-      "name": "BlackDiamondSCInc1",
-      "symbol": "BDSCI1"
-    },
-    "token1": {
-      "id": "0xd039c9079ca7f2a87d632a9c0d7cea0137bacfb5",
-      "name": "Ape / X",
-      "symbol": "APE / X"
-    }
-  },
-  {
-    "name": "AVAX / HON",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xed2b42d3c9c6e97e11755bb37df29b6375ede3eb",
-      "name": "HonToken",
-      "symbol": "HON"
-    }
-  },
-  {
-    "name": "USDC.e / OT / qiAVAX / 28DEC2023",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xecc5748b1ff6b23f284ec81e8bf034409961d8dc",
-      "name": "OT Benqi AVAX 28DEC2023",
-      "symbol": "OT / qiAVAX / 28DEC2023"
-    }
-  },
-  {
-    "name": "GRAPE / WINE",
-    "token0": {
-      "id": "0x5541d83efad1f281571b343977648b75d95cdac2",
-      "name": "Grape Finance",
-      "symbol": "GRAPE"
-    },
-    "token1": {
-      "id": "0xc55036b5348cfb45a932481744645985010d3a44",
-      "name": "Wine Shares",
-      "symbol": "WINE"
-    }
-  },
-  {
-    "name": "USDC.e / DAI.e",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-      "name": "Dai Stablecoin",
-      "symbol": "DAI.e"
-    }
-  },
-  {
-    "name": "STEAK / AVAX",
-    "token0": {
-      "id": "0xb279f8dd152b99ec1d84a489d32c35bc0c7f5674",
-      "name": "STEAK",
-      "symbol": "STEAK"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "DCAU / AVAX",
-    "token0": {
-      "id": "0x100cc3a819dd3e8573fd2e46d1e66ee866068f30",
-      "name": "Dragon Crypto Aurum",
-      "symbol": "DCAU"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "3ULL / AVAX",
-    "token0": {
-      "id": "0x9e15f045e44ea5a80e7fbc193a35287712cc5569",
-      "name": "3ULL v2",
-      "symbol": "3ULL"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "POLAR / AVAX",
-    "token0": {
-      "id": "0x6c1c0319d8ddcb0ffe1a68c5b3829fd361587db4",
-      "name": "POLAR",
-      "symbol": "POLAR"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "DBY / AVAX",
-    "token0": {
-      "id": "0x5085434227ab73151fad2de546210cbc8663df96",
-      "name": "Metaderby token",
-      "symbol": "DBY"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "JADE / USDC",
-    "token0": {
-      "id": "0x80b010450fdaf6a3f8df033ee296e92751d603b3",
-      "name": "Jade Protocol",
-      "symbol": "JADE"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "PAE / AVAX",
-    "token0": {
-      "id": "0x9466ab927611725b9af76b9f31b2f879ff14233d",
-      "name": "Ripae",
-      "symbol": "PAE"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "ASAFTI / AVAX",
-    "token0": {
-      "id": "0x8832d30286907612952aafc3d249e79e39732dcc",
-      "name": "SafuTitano",
-      "symbol": "ASAFTI"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / DOMI",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xfc6da929c031162841370af240dec19099861d3b",
-      "name": "Domi",
-      "symbol": "DOMI"
-    }
-  },
-  {
-    "name": "XETA / USDC",
-    "token0": {
-      "id": "0x31c994ac062c1970c086260bc61babb708643fac",
-      "name": "XANA",
-      "symbol": "XETA"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "KINE / USDT.e",
-    "token0": {
-      "id": "0xa9c1740fa56e4c0f6ce5a792fd27095c8b6ccd87",
-      "name": "Kine Governance Token",
-      "symbol": "KINE"
-    },
-    "token1": {
-      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
-      "name": "Tether USD",
-      "symbol": "USDT.e"
-    }
-  },
-  {
-    "name": "AVAX / LiPOGE",
-    "token0": {
-      "id": "0x631a499e79fb46e2ab7e4a5f18e3391ad32386b6",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd9e8ae66782529b3fc9157af2b6fa137bea46e5d",
-      "name": "iLiPogeCoin",
-      "symbol": "LiPOGE"
-    }
-  },
-  {
-    "name": "DCAU / USDT.e",
-    "token0": {
-      "id": "0x100cc3a819dd3e8573fd2e46d1e66ee866068f30",
-      "name": "Dragon Crypto Aurum",
-      "symbol": "DCAU"
-    },
-    "token1": {
-      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
-      "name": "Tether USD",
-      "symbol": "USDT.e"
-    }
-  },
-  {
-    "name": "MIM / FORT",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0xf6d46849db378ae01d93732585bec2c4480d1fd5",
-      "name": "Fort",
-      "symbol": "FORT"
-    }
-  },
-  {
-    "name": "FLY / AVAX",
-    "token0": {
-      "id": "0x78ea3fef1c1f07348199bf44f45b803b9b0dbe28",
-      "name": "FLY",
-      "symbol": "FLY"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAL / USDC.e",
-    "token0": {
-      "id": "0xa216f344fcd412c129e0c012798a137e332f8955",
-      "name": "Avalend Finance",
-      "symbol": "AVAL"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "MEAD / AVAX",
-    "token0": {
-      "id": "0x44a45a9baeb63c6ea4860ecf9ac5732c330c4d4e",
-      "name": "Thors Mead V2",
-      "symbol": "MEAD"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "FOOK / AVAX",
-    "token0": {
-      "id": "0x95923f63da09b4f7520f7c65a31f318d8228b744",
-      "name": "FOOK Token",
-      "symbol": "FOOK"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "USDC.e / RUG",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xb8ef3a190b68175000b74b4160d325fd5024760e",
-      "name": "R U Generous",
-      "symbol": "RUG"
-    }
-  },
-  {
-    "name": "USDT.e / DAI.e",
-    "token0": {
-      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
-      "name": "Tether USD",
-      "symbol": "USDT.e"
-    },
-    "token1": {
-      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-      "name": "Dai Stablecoin",
-      "symbol": "DAI.e"
-    }
-  },
-  {
-    "name": "AVAX / LVT",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xff579d6259dedcc80488c9b89d2820bcb5609160",
-      "name": "Louverture",
-      "symbol": "LVT"
-    }
-  },
-  {
-    "name": "SMRT / AVAX",
-    "token0": {
-      "id": "0x712b05710bcfe9c9b1df08d0f846f42c3d457f3e",
-      "name": "SmartNodes",
-      "symbol": "SMRT"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "KLO / AVAX",
-    "token0": {
-      "id": "0xb27c8941a7df8958a1778c0259f76d1f8b711c35",
-      "name": "Kalao Token",
-      "symbol": "KLO"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "LiPOGE / AVAX",
-    "token0": {
-      "id": "0x168c14b83c959778b6b8c4e4fa0c20af8df23e61",
-      "name": "iLiPoge Coin",
-      "symbol": "LiPOGE"
-    },
-    "token1": {
-      "id": "0x631a499e79fb46e2ab7e4a5f18e3391ad32386b6",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "WETH.e / USDC.e",
-    "token0": {
-      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
-      "name": "Wrapped Ether",
-      "symbol": "WETH.e"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "AVAX / CLY",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xec3492a2508ddf4fdc0cd76f31f340b30d1793e6",
-      "name": "Colony Token",
-      "symbol": "CLY"
-    }
-  },
-  {
-    "name": "USDibs / WLRS",
-    "token0": {
-      "id": "0x0efa5328fefce96c8d10661bd97403764d477853",
-      "name": "Dibs USD",
-      "symbol": "USDibs"
-    },
-    "token1": {
-      "id": "0x395908aeb53d33a9b8ac35e148e9805d34a555d3",
-      "name": "frozenwalrus.finance",
-      "symbol": "WLRS"
-    }
-  },
-  {
-    "name": "MIND+ / AVAX",
-    "token0": {
-      "id": "0x92876c3a3e2b0788c841587a14989392a555bffe",
-      "name": "MIND+",
-      "symbol": "MIND+"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVIC / USDC",
-    "token0": {
-      "id": "0x59b18817ca9f4ad2dee6fbf30132df6aeb9d763d",
-      "name": "Victory",
-      "symbol": "AVIC"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "SLIME / AVAX",
-    "token0": {
-      "id": "0x5a15bdcf9a3a8e799fa4381e666466a516f2d9c8",
-      "name": "Snail Trail",
-      "symbol": "SLIME"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "MIM / USDC.e",
-    "token0": {
-      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-      "name": "Magic Internet Money",
-      "symbol": "MIM"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "AVAX / TUS",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xf693248f96fe03422fea95ac0afbbbc4a8fdd172",
-      "name": "Treasure Under Sea",
-      "symbol": "TUS"
-    }
-  },
-  {
-    "name": "AVAX / CINU",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xc11bf915db4b43714bc8d32bf83bf5ea53d40981",
-      "name": "CHEEMSINU",
-      "symbol": "CINU"
-    }
-  },
-  {
-    "name": "SCAT / DAI.e",
-    "token0": {
-      "id": "0xbe3e1f44d99edb10cf6378e5a3879bb533a67331",
-      "name": "SnowCat",
-      "symbol": "SCAT"
-    },
-    "token1": {
-      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-      "name": "Dai Stablecoin",
-      "symbol": "DAI.e"
-    }
-  },
-  {
-    "name": "MAGIC / USDC",
-    "token0": {
-      "id": "0x9a8e0217cd870783c3f2317985c57bf570969153",
-      "name": "Magic",
-      "symbol": "MAGIC"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "QI / AVAX",
-    "token0": {
-      "id": "0x8729438eb15e2c8b576fcc6aecda6a148776c0f5",
-      "name": "BENQI",
-      "symbol": "QI"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / CCY",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xb723783e0f9015c8e20b87f6cf7ae24df6479e62",
-      "name": "ChoccyCoin",
-      "symbol": "CCY"
-    }
-  },
-  {
-    "name": "MELT / AVAX",
-    "token0": {
-      "id": "0x47eb6f7525c1aa999fbc9ee92715f5231eb1241d",
-      "name": "Defrost Finance Token",
-      "symbol": "MELT"
+      "id": "0x264c1383ea520f73dd837f915ef3a732e204a493",
+      "name": "Binance",
+      "symbol": "BNB"
     },
     "token1": {
       "id": "AVAX",
@@ -1963,37 +650,76 @@
     }
   },
   {
-    "name": "USDC.e / XLGS",
+    "name": "WET / AVAX",
     "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
+      "id": "0xb1466d4cf0dcfc0bcddcf3500f473cdacb88b56d",
+      "name": "Weble Ecosystem Token",
+      "symbol": "WET"
     },
     "token1": {
-      "id": "0xcd6d596adb9070b5075d1309bc0b4ea7d9ddb821",
-      "name": "LegionSwap",
-      "symbol": "XLGS"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
     }
   },
   {
-    "name": "AVAX / AXL",
+    "name": "BUSD / AVAX",
     "token0": {
-      "id": "0x819f75f9e4fb6609716e120c8549c21769c79f7f",
+      "id": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
+      "name": "BUSD Token",
+      "symbol": "BUSD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / ECD",
+    "token0": {
+      "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
     },
     "token1": {
-      "id": "0xd97ff0f7be2e2a0c7b4b3a2f41b74d2b636aee78",
-      "name": "Axxeleum Finance",
-      "symbol": "AXL"
+      "id": "0xeb8343d5284caec921f035207ca94db6baaacbcd",
+      "name": "Echidna Token",
+      "symbol": "ECD"
     }
   },
   {
-    "name": "BDAO / USDC",
+    "name": "CAI / AVAX",
     "token0": {
-      "id": "0x83c7412931398502922a35911e5fab221822f4b6",
-      "name": "Bamboo DAO Shares",
-      "symbol": "BDAO"
+      "id": "0x48f88a3fe843ccb0b5003e70b4192c1d7448bef0",
+      "name": "Colony Avalanche Index",
+      "symbol": "CAI"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "JOE / USDT.e",
+    "token0": {
+      "id": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
+      "name": "JoeToken",
+      "symbol": "JOE"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "XETA / USDC",
+    "token0": {
+      "id": "0x31c994ac062c1970c086260bc61babb708643fac",
+      "name": "XANA",
+      "symbol": "XETA"
     },
     "token1": {
       "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
@@ -2002,11 +728,24 @@
     }
   },
   {
-    "name": "BioFi / AVAX",
+    "name": "AUX / USDC",
     "token0": {
-      "id": "0x9366d30feba284e62900f6295bc28c9906f33172",
-      "name": "BioFi",
-      "symbol": "BioFi"
+      "id": "0x68327a91e79f87f501bc8522fc333fb7a72393cb",
+      "name": "AUX Coin",
+      "symbol": "AUX"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "CRA / AVAX",
+    "token0": {
+      "id": "0xa32608e873f9ddef944b24798db69d80bbb4d1ed",
+      "name": "CRA",
+      "symbol": "CRA"
     },
     "token1": {
       "id": "AVAX",
@@ -2015,11 +754,11 @@
     }
   },
   {
-    "name": "APE / AVAX",
+    "name": "ASAFTI / AVAX",
     "token0": {
-      "id": "0x0802d66f029c46e042b74d543fc43b6705ccb4ba",
-      "name": "ApeCoin",
-      "symbol": "APE"
+      "id": "0x8832d30286907612952aafc3d249e79e39732dcc",
+      "name": "SafuTitano",
+      "symbol": "ASAFTI"
     },
     "token1": {
       "id": "AVAX",
@@ -2028,29 +767,341 @@
     }
   },
   {
-    "name": "AVAX / CHRO",
+    "name": "KINE / USDT.e",
     "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
+      "id": "0xa9c1740fa56e4c0f6ce5a792fd27095c8b6ccd87",
+      "name": "Kine Governance Token",
+      "symbol": "KINE"
     },
     "token1": {
-      "id": "0xbf1230bb63bfd7f5d628ab7b543bcefa8a24b81b",
-      "name": "Chronicum",
-      "symbol": "CHRO"
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
     }
   },
   {
-    "name": "AVAX / AXIAL",
+    "name": "USDC.e / USDT.e",
+    "token0": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "pAVAX / AVAX",
+    "token0": {
+      "id": "0x6ca558bd3eab53da1b25ab97916dd14bf6cfee4e",
+      "name": "pAVAX",
+      "symbol": "pAVAX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "JADE / USDC",
+    "token0": {
+      "id": "0x80b010450fdaf6a3f8df033ee296e92751d603b3",
+      "name": "Jade Protocol",
+      "symbol": "JADE"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "STEAK / AVAX",
+    "token0": {
+      "id": "0xb279f8dd152b99ec1d84a489d32c35bc0c7f5674",
+      "name": "STEAK",
+      "symbol": "STEAK"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "QI / AVAX",
+    "token0": {
+      "id": "0xa56f9a54880afbc30cf29bb66d2d9adcdcaeadd6",
+      "name": "Qi Dao Protocol",
+      "symbol": "QI"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "WBTC.e / USDC.e",
+    "token0": {
+      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
+      "name": "Wrapped BTC",
+      "symbol": "WBTC.e"
+    },
+    "token1": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
+    }
+  },
+  {
+    "name": "MIM / FORT",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xf6d46849db378ae01d93732585bec2c4480d1fd5",
+      "name": "Fort",
+      "symbol": "FORT"
+    }
+  },
+  {
+    "name": "MIM / ASND",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xfd0c58f03c83d6960bb9dbfd45076d78df2f095d",
+      "name": "Ascend",
+      "symbol": "ASND"
+    }
+  },
+  {
+    "name": "$ALPHA / AVAX",
+    "token0": {
+      "id": "0x325a98f258a5732c7b06555603f6af5bc1c17f0a",
+      "name": "$ALPHA",
+      "symbol": "$ALPHA"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "NNT / USDC",
+    "token0": {
+      "id": "0x771c01e1917b5ab5b791f7b96f0cd69e22f6dbcf",
+      "name": "NunuToken",
+      "symbol": "NNT"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / HON",
     "token0": {
       "id": "AVAX",
       "name": "AVAX",
       "symbol": "AVAX"
     },
     "token1": {
-      "id": "0xcf8419a615c57511807236751c0af38db4ba3351",
-      "name": "AxialToken",
-      "symbol": "AXIAL"
+      "id": "0xed2b42d3c9c6e97e11755bb37df29b6375ede3eb",
+      "name": "HonToken",
+      "symbol": "HON"
+    }
+  },
+  {
+    "name": "LIQR / AVAX",
+    "token0": {
+      "id": "0x33333ee26a7d02e41c33828b42fb1e0889143477",
+      "name": "LIQR",
+      "symbol": "LIQR"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "PLAYMATES / AVAX",
+    "token0": {
+      "id": "0x490bf3abcab1fb5c88533d850f2a8d6d38298465",
+      "name": "Playmates",
+      "symbol": "PLAYMATES"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DCAU / USDT.e",
+    "token0": {
+      "id": "0x100cc3a819dd3e8573fd2e46d1e66ee866068f30",
+      "name": "Dragon Crypto Aurum",
+      "symbol": "DCAU"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "3ULL / AVAX",
+    "token0": {
+      "id": "0x9e15f045e44ea5a80e7fbc193a35287712cc5569",
+      "name": "3ULL v2",
+      "symbol": "3ULL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / CINU",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc11bf915db4b43714bc8d32bf83bf5ea53d40981",
+      "name": "CHEEMSINU",
+      "symbol": "CINU"
+    }
+  },
+  {
+    "name": "USDT.e / DAI.e",
+    "token0": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    },
+    "token1": {
+      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI.e"
+    }
+  },
+  {
+    "name": "ORBIT / AVAX",
+    "token0": {
+      "id": "0x340990358ae38008181b6db6156d9021a2d425da",
+      "name": "Europa Token",
+      "symbol": "ORBIT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SNCT / AVAX",
+    "token0": {
+      "id": "0x2905d6d6957983d9ed73bc019ff2782c39dd7a49",
+      "name": "Snake City Token",
+      "symbol": "SNCT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BSN / AVAX",
+    "token0": {
+      "id": "0x237bed318a3bb26bdb3790901a7a79cf53c7b80f",
+      "name": "Black Shark Nodes",
+      "symbol": "BSN"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SLIME / AVAX",
+    "token0": {
+      "id": "0x5a15bdcf9a3a8e799fa4381e666466a516f2d9c8",
+      "name": "Snail Trail",
+      "symbol": "SLIME"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / LVT",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xff579d6259dedcc80488c9b89d2820bcb5609160",
+      "name": "Louverture",
+      "symbol": "LVT"
+    }
+  },
+  {
+    "name": "DGNX / AVAX",
+    "token0": {
+      "id": "0x51e48670098173025c477d9aa3f0eff7bf9f7812",
+      "name": "DegenX",
+      "symbol": "DGNX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FEED / AVAX",
+    "token0": {
+      "id": "0xab592d197acc575d16c3346f4eb70c703f308d1e",
+      "name": "chikn feed",
+      "symbol": "FEED"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / IME",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xf891214fdcf9cdaa5fdc42369ee4f27f226adad6",
+      "name": "Imperium Empires Token",
+      "symbol": "IME"
     }
   },
   {
@@ -2067,24 +1118,24 @@
     }
   },
   {
-    "name": "PTP / ecdPTP",
+    "name": "SPEAR / USDC",
     "token0": {
-      "id": "0x22d4002028f537599be9f666d1c4fa138522f9c8",
-      "name": "Platypus",
-      "symbol": "PTP"
+      "id": "0x4860a28be33ad04dadfc91722728effa8430f836",
+      "name": "SpearFinanceRewardsToken",
+      "symbol": "SPEAR"
     },
     "token1": {
-      "id": "0xb2c5172e5c15af6add1ec92e518a5ea1c7ded2ad",
-      "name": "Echidna PTP",
-      "symbol": "ecdPTP"
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
     }
   },
   {
-    "name": "FXS / AVAX",
+    "name": "RADX / AVAX",
     "token0": {
-      "id": "0x214db107654ff987ad859f34125307783fc8e387",
-      "name": "Frax Share",
-      "symbol": "FXS"
+      "id": "0x4e616781195833722c124a95c4670624a433acb1",
+      "name": "Radix",
+      "symbol": "RADX"
     },
     "token1": {
       "id": "AVAX",
@@ -2093,11 +1144,141 @@
     }
   },
   {
-    "name": "OH / AVAX",
+    "name": "AVAX / CLY",
     "token0": {
-      "id": "0x937e077abaea52d3abf879c9b9d3f2ebd15baa21",
-      "name": "Oh! Finance",
-      "symbol": "OH"
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xec3492a2508ddf4fdc0cd76f31f340b30d1793e6",
+      "name": "Colony Token",
+      "symbol": "CLY"
+    }
+  },
+  {
+    "name": "AFINS / USDC",
+    "token0": {
+      "id": "0xb648fa7a5f5ed3b3c743140346e3dc3fe94a9125",
+      "name": "altFINS",
+      "symbol": "AFINS"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / TUS",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xf693248f96fe03422fea95ac0afbbbc4a8fdd172",
+      "name": "Treasure Under Sea",
+      "symbol": "TUS"
+    }
+  },
+  {
+    "name": "BRO / AVAX",
+    "token0": {
+      "id": "0x65031e28cb0e8cc21ae411f9dd22c9b1bd260ce4",
+      "name": "Bro Token",
+      "symbol": "BRO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DBY / AVAX",
+    "token0": {
+      "id": "0x5085434227ab73151fad2de546210cbc8663df96",
+      "name": "Metaderby token",
+      "symbol": "DBY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / USDC.e",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
+    }
+  },
+  {
+    "name": "AVAX / DOMI",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfc6da929c031162841370af240dec19099861d3b",
+      "name": "Domi",
+      "symbol": "DOMI"
+    }
+  },
+  {
+    "name": "KGC / USDT.e",
+    "token0": {
+      "id": "0x54a77f27d2346c3a8f5b43a501434f0f21f33e3c",
+      "name": "Kingdom Gold Coin",
+      "symbol": "KGC"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "AVAX / MORE",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd9d90f882cddd6063959a9d837b05cb748718a05",
+      "name": "More Token",
+      "symbol": "MORE"
+    }
+  },
+  {
+    "name": "USDC / LODE",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xbbaaa0420d474b34be197f95a323c2ff3829e811",
+      "name": "LODE Token",
+      "symbol": "LODE"
+    }
+  },
+  {
+    "name": "DCAU / AVAX",
+    "token0": {
+      "id": "0x100cc3a819dd3e8573fd2e46d1e66ee866068f30",
+      "name": "Dragon Crypto Aurum",
+      "symbol": "DCAU"
     },
     "token1": {
       "id": "AVAX",
@@ -2119,427 +1300,11 @@
     }
   },
   {
-    "name": "BSN / AVAX",
+    "name": "KLO / AVAX",
     "token0": {
-      "id": "0x237bed318a3bb26bdb3790901a7a79cf53c7b80f",
-      "name": "Black Shark Nodes",
-      "symbol": "BSN"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "XIO / USDC",
-    "token0": {
-      "id": "0x2cf51e73c3516f3d86e9c0b4de0971dbf0766fd4",
-      "name": "XIO Network",
-      "symbol": "XIO"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "AVAX / YEL",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xc5e7520432ebdbf0a610287ac45fc231876f5e99",
-      "name": "YEL Token",
-      "symbol": "YEL"
-    }
-  },
-  {
-    "name": "Dice / Dice",
-    "token0": {
-      "id": "0x0b47d67a059a22fc741faadf2d2bcf216d3cdd7a",
-      "name": "Dice DAO",
-      "symbol": "Dice"
-    },
-    "token1": {
-      "id": "0xdd30bd91d9424a6c618eecffca56179128e1c88a",
-      "name": "Dice DAO",
-      "symbol": "Dice"
-    }
-  },
-  {
-    "name": "USDC / PND",
-    "token0": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    },
-    "token1": {
-      "id": "0xd8a30ba14128193a02f90e2d5eaa943bc446630d",
-      "name": "Panda Finance",
-      "symbol": "PND"
-    }
-  },
-  {
-    "name": "PIZZA / RONI",
-    "token0": {
-      "id": "0x6121191018baf067c6dc6b18d42329447a164f05",
-      "name": "Pizza",
-      "symbol": "PIZZA"
-    },
-    "token1": {
-      "id": "0xe52459f8e93d3ee8aec834fee8f8dbbe1b964cec",
-      "name": "Pepperoni",
-      "symbol": "RONI"
-    }
-  },
-  {
-    "name": "YUSD / AVAX",
-    "token0": {
-      "id": "0x111111111111ed1d73f860f57b2798b683f2d325",
-      "name": "YUSD Stablecoin",
-      "symbol": "YUSD"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / HeC",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xc7f4debc8072e23fe9259a5c0398326d8efb7f5c",
-      "name": "HeroesChained",
-      "symbol": "HeC"
-    }
-  },
-  {
-    "name": "DLC / USDC",
-    "token0": {
-      "id": "0x6cc8ef6cfc173fc55a920c29e05222dead33b573",
-      "name": "DashLeague Crystals",
-      "symbol": "DLC"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "USDC.e / BAVA",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xe19a1684873fab5fb694cfd06607100a632ff21c",
-      "name": "BavaToken",
-      "symbol": "BAVA"
-    }
-  },
-  {
-    "name": "LINK.e / USDC.e",
-    "token0": {
-      "id": "0x5947bb275c521040051d82396192181b413227a3",
-      "name": "Chainlink Token",
-      "symbol": "LINK.e"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "Yuzu / USDC.e",
-    "token0": {
-      "id": "0x6cf7e3814dd76ac20086359802dd2eba5d99012d",
-      "name": "Yuzu Node",
-      "symbol": "Yuzu"
-    },
-    "token1": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    }
-  },
-  {
-    "name": "AVAX / MORE",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd9d90f882cddd6063959a9d837b05cb748718a05",
-      "name": "More Token",
-      "symbol": "MORE"
-    }
-  },
-  {
-    "name": "NNT / USDC",
-    "token0": {
-      "id": "0x771c01e1917b5ab5b791f7b96f0cd69e22f6dbcf",
-      "name": "NunuToken",
-      "symbol": "NNT"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "PINT / USDC",
-    "token0": {
-      "id": "0x3af0eb8bcbd4c4c6e26e309c4e47af59bad5fc2f",
-      "name": "pub.finance",
-      "symbol": "PINT"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "AMPL / AVAX",
-    "token0": {
-      "id": "0x027dbca046ca156de9622cd1e2d907d375e53aa7",
-      "name": "Ampleforth secured by Meter Passport",
-      "symbol": "AMPL"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "UNCL / AVAX",
-    "token0": {
-      "id": "0x7d86f1eaff29f076576b2ff09ce3bcc7533fd2c5",
-      "name": "UNCL",
-      "symbol": "UNCL"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / LVT",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xd641e62525e830e98cb9d7d033a538a1f092ff34",
-      "name": "Louverture v2",
-      "symbol": "LVT"
-    }
-  },
-  {
-    "name": "AVAX / NEIBR",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xe337a99fe0ac0f3e01a97167d21082a2bb96326e",
-      "name": "The Neighbours",
-      "symbol": "NEIBR"
-    }
-  },
-  {
-    "name": "MAGIC / AVAX",
-    "token0": {
-      "id": "0x9a8e0217cd870783c3f2317985c57bf570969153",
-      "name": "Magic",
-      "symbol": "MAGIC"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "VSO / AVAX",
-    "token0": {
-      "id": "0x846d50248baf8b7ceaa9d9b53bfd12d7d7fbb25a",
-      "name": "VersoToken",
-      "symbol": "VSO"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / URQA",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xbd3936ec8d83a5d4e73eca625ecfa006da8c8f52",
-      "name": "UREEQA Token [via ChainPort.io]",
-      "symbol": "URQA"
-    }
-  },
-  {
-    "name": "AVAT / USDC",
-    "token0": {
-      "id": "0x7086c48c997b8597a1692798155b4fcf2cee7f0f",
-      "name": "AVAT",
-      "symbol": "AVAT"
-    },
-    "token1": {
-      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
-      "name": "USD Coin",
-      "symbol": "USDC"
-    }
-  },
-  {
-    "name": "USDT / LiPOGE",
-    "token0": {
-      "id": "0xb91411de29ffcd75c3c816cfb1a8e24b13c86f4a",
-      "name": "TetherToken",
-      "symbol": "USDT"
-    },
-    "token1": {
-      "id": "0xd9e8ae66782529b3fc9157af2b6fa137bea46e5d",
-      "name": "iLiPogeCoin",
-      "symbol": "LiPOGE"
-    }
-  },
-  {
-    "name": "LOST / AVAX",
-    "token0": {
-      "id": "0x449674b82f05d498e126dd6615a1057a9c088f2c",
-      "name": "LostToken",
-      "symbol": "LOST"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "AVAX / TIME",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xb54f16fb19478766a268f172c9480f8da1a7c9c3",
-      "name": "Time",
-      "symbol": "TIME"
-    }
-  },
-  {
-    "name": "AVAX / SPELL",
-    "token0": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    },
-    "token1": {
-      "id": "0xce1bffbd5374dac86a2893119683f4911a2f7814",
-      "name": "Spell Token",
-      "symbol": "SPELL"
-    }
-  },
-  {
-    "name": "DFIAT / AVAX",
-    "token0": {
-      "id": "0xafe3d2a31231230875dee1fa1eef14a412443d22",
-      "name": "DeFiato [via ChainPort.io]",
-      "symbol": "DFIAT"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "BEE / TEST",
-    "token0": {
-      "id": "0x5b4192b5636f7b6ab6d963865963e92bbba5aac0",
-      "name": "BCoin",
-      "symbol": "BEE"
-    },
-    "token1": {
-      "id": "0xa6dbd0f6b39a2383d4558dd23e84c0210a007151",
-      "name": "TestCoin",
-      "symbol": "TEST"
-    }
-  },
-  {
-    "name": "USDC.e / UNCLE",
-    "token0": {
-      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
-      "name": "USD Coin",
-      "symbol": "USDC.e"
-    },
-    "token1": {
-      "id": "0xf49fe07b97bbfaa474614a43259d460e4c84f6fa",
-      "name": "Uncle",
-      "symbol": "UNCLE"
-    }
-  },
-  {
-    "name": "RELAY / AVAX",
-    "token0": {
-      "id": "0x78c42324016cd91d1827924711563fb66e33a83a",
-      "name": "Relay Token",
-      "symbol": "RELAY"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "ZEUS / AVAX",
-    "token0": {
-      "id": "0x4156f18bf7c1ef04248632c66aa119de152d8f2e",
-      "name": "Zeus Node Finance",
-      "symbol": "ZEUS"
-    },
-    "token1": {
-      "id": "AVAX",
-      "name": "AVAX",
-      "symbol": "AVAX"
-    }
-  },
-  {
-    "name": "PRMD / AVAX",
-    "token0": {
-      "id": "0x74c2a8a0161ff501d44a71c2e2dfdb5485912b1f",
-      "name": "Pyramid",
-      "symbol": "PRMD"
+      "id": "0xb27c8941a7df8958a1778c0259f76d1f8b711c35",
+      "name": "Kalao Token",
+      "symbol": "KLO"
     },
     "token1": {
       "id": "AVAX",
@@ -2561,11 +1326,440 @@
     }
   },
   {
-    "name": "ISA / AVAX",
+    "name": "AMPL / AVAX",
     "token0": {
-      "id": "0x3eefb18003d033661f84e48360ebecd181a84709",
-      "name": "Islander",
-      "symbol": "ISA"
+      "id": "0x027dbca046ca156de9622cd1e2d907d375e53aa7",
+      "name": "Ampleforth secured by Meter Passport",
+      "symbol": "AMPL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIND+ / AVAX",
+    "token0": {
+      "id": "0x92876c3a3e2b0788c841587a14989392a555bffe",
+      "name": "MIND+",
+      "symbol": "MIND+"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "OH / AVAX",
+    "token0": {
+      "id": "0x937e077abaea52d3abf879c9b9d3f2ebd15baa21",
+      "name": "Oh! Finance",
+      "symbol": "OH"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BioFi / AVAX",
+    "token0": {
+      "id": "0x9366d30feba284e62900f6295bc28c9906f33172",
+      "name": "BioFi",
+      "symbol": "BioFi"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MEAD / AVAX",
+    "token0": {
+      "id": "0x44a45a9baeb63c6ea4860ecf9ac5732c330c4d4e",
+      "name": "Thors Mead V2",
+      "symbol": "MEAD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FERT / AVAX",
+    "token0": {
+      "id": "0x9c846d808a41328a209e235b5e3c4e626dab169e",
+      "name": "chikn fert",
+      "symbol": "FERT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AGX / USDC",
+    "token0": {
+      "id": "0x13e7bcefdde72492e656f3fa58bae6029708e673",
+      "name": "AGX Coin",
+      "symbol": "AGX"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "FLY / AVAX",
+    "token0": {
+      "id": "0x78ea3fef1c1f07348199bf44f45b803b9b0dbe28",
+      "name": "FLY",
+      "symbol": "FLY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MAGIC / AVAX",
+    "token0": {
+      "id": "0x9a8e0217cd870783c3f2317985c57bf570969153",
+      "name": "Magic",
+      "symbol": "MAGIC"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "WETH.e / USDC.e",
+    "token0": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    },
+    "token1": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
+    }
+  },
+  {
+    "name": "DEG / AVAX",
+    "token0": {
+      "id": "0x9f285507ea5b4f33822ca7abb5ec8953ce37a645",
+      "name": "DegisToken",
+      "symbol": "DEG"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "RTFY / USDC",
+    "token0": {
+      "id": "0x69b31d508f755d77d5d1dc063f6c4f800a0bf8de",
+      "name": "Ratify",
+      "symbol": "RTFY"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / CHRO",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xbf1230bb63bfd7f5d628ab7b543bcefa8a24b81b",
+      "name": "Chronicum",
+      "symbol": "CHRO"
+    }
+  },
+  {
+    "name": "AVAX / YEL",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc5e7520432ebdbf0a610287ac45fc231876f5e99",
+      "name": "YEL Token",
+      "symbol": "YEL"
+    }
+  },
+  {
+    "name": "USDC.e / DAI.e",
+    "token0": {
+      "id": "0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664",
+      "name": "USD Coin",
+      "symbol": "USDC.e"
+    },
+    "token1": {
+      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI.e"
+    }
+  },
+  {
+    "name": "MELT / AVAX",
+    "token0": {
+      "id": "0x47eb6f7525c1aa999fbc9ee92715f5231eb1241d",
+      "name": "Defrost Finance Token",
+      "symbol": "MELT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MAGIC / USDC",
+    "token0": {
+      "id": "0x9a8e0217cd870783c3f2317985c57bf570969153",
+      "name": "Magic",
+      "symbol": "MAGIC"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / OCapital",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe5cc9bb854163ddb1b4525e7c538fc32de5000d3",
+      "name": "Orange Capital",
+      "symbol": "OCapital"
+    }
+  },
+  {
+    "name": "AVAX / TIME",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb54f16fb19478766a268f172c9480f8da1a7c9c3",
+      "name": "Time",
+      "symbol": "TIME"
+    }
+  },
+  {
+    "name": "AVAX / $BURN",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xdb9438f5e3afa5ced760be9692604c3c5ab816d1",
+      "name": "Snow Burn",
+      "symbol": "$BURN"
+    }
+  },
+  {
+    "name": "MIM / SBR",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x19613fec180746831bdf819e0790f35741040dfd",
+      "name": "Snowbear",
+      "symbol": "SBR"
+    }
+  },
+  {
+    "name": "AVAX / CHAM",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc65bc1e906771e105fbacbd8dfe3862ee7be378e",
+      "name": "Champion",
+      "symbol": "CHAM"
+    }
+  },
+  {
+    "name": "AVAX / CCY",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb723783e0f9015c8e20b87f6cf7ae24df6479e62",
+      "name": "ChoccyCoin",
+      "symbol": "CCY"
+    }
+  },
+  {
+    "name": "PBX / AVAX",
+    "token0": {
+      "id": "0x7289eaef1f33b30929f3c4e6cdb1b64caf52632f",
+      "name": "Polarbets.io V2",
+      "symbol": "PBX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "VSO / AVAX",
+    "token0": {
+      "id": "0x846d50248baf8b7ceaa9d9b53bfd12d7d7fbb25a",
+      "name": "VersoToken",
+      "symbol": "VSO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / HeC",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc7f4debc8072e23fe9259a5c0398326d8efb7f5c",
+      "name": "HeroesChained",
+      "symbol": "HeC"
+    }
+  },
+  {
+    "name": "AVAX / LVT",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd641e62525e830e98cb9d7d033a538a1f092ff34",
+      "name": "Louverture v2",
+      "symbol": "LVT"
+    }
+  },
+  {
+    "name": "AVAT / USDC",
+    "token0": {
+      "id": "0x7086c48c997b8597a1692798155b4fcf2cee7f0f",
+      "name": "AVAT",
+      "symbol": "AVAT"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "DFIAT / AVAX",
+    "token0": {
+      "id": "0xafe3d2a31231230875dee1fa1eef14a412443d22",
+      "name": "DeFiato [via ChainPort.io]",
+      "symbol": "DFIAT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / BETS",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc763f8570a48c4c00c80b76107cbe744dda67b79",
+      "name": "BetSwirl Token",
+      "symbol": "BETS"
+    }
+  },
+  {
+    "name": "UNCL / AVAX",
+    "token0": {
+      "id": "0x7d86f1eaff29f076576b2ff09ce3bcc7533fd2c5",
+      "name": "UNCL",
+      "symbol": "UNCL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / URQA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xbd3936ec8d83a5d4e73eca625ecfa006da8c8f52",
+      "name": "UREEQA Token [via ChainPort.io]",
+      "symbol": "URQA"
+    }
+  },
+  {
+    "name": "XIO / USDC",
+    "token0": {
+      "id": "0x2cf51e73c3516f3d86e9c0b4de0971dbf0766fd4",
+      "name": "XIO Network",
+      "symbol": "XIO"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "PRMD / AVAX",
+    "token0": {
+      "id": "0x74c2a8a0161ff501d44a71c2e2dfdb5485912b1f",
+      "name": "Pyramid",
+      "symbol": "PRMD"
     },
     "token1": {
       "id": "AVAX",
@@ -2587,6 +1781,669 @@
     }
   },
   {
+    "name": "APEX / AVAX",
+    "token0": {
+      "id": "0x2e768e86f691afe8a6f9277bbcd9c570ab868fc0",
+      "name": "Apex",
+      "symbol": "APEX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / SPELL",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xce1bffbd5374dac86a2893119683f4911a2f7814",
+      "name": "Spell Token",
+      "symbol": "SPELL"
+    }
+  },
+  {
+    "name": "USDT.e / SAC",
+    "token0": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    },
+    "token1": {
+      "id": "0xce983dc04135107ca9e59fe8102e07da5d133937",
+      "name": "Search Neuron",
+      "symbol": "SAC"
+    }
+  },
+  {
+    "name": "WETH.e / EVIC",
+    "token0": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    },
+    "token1": {
+      "id": "0x74fefa839a96a1632a29e0fcf0907d0f88528658",
+      "name": "Ethereum Victory",
+      "symbol": "EVIC"
+    }
+  },
+  {
+    "name": "AVAX / UST",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb599c3590f42f8f995ecfa0f85d2980b76862fc1",
+      "name": "UST (Wormhole)",
+      "symbol": "UST"
+    }
+  },
+  {
+    "name": "WETH.e / USDC",
+    "token0": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / AXIAL",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xcf8419a615c57511807236751c0af38db4ba3351",
+      "name": "AxialToken",
+      "symbol": "AXIAL"
+    }
+  },
+  {
+    "name": "ISA / AVAX",
+    "token0": {
+      "id": "0x3eefb18003d033661f84e48360ebecd181a84709",
+      "name": "Islander",
+      "symbol": "ISA"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / MMAC",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xdd33ef5704ada19d254cb636b5a0a1bad3936050",
+      "name": "MMAC",
+      "symbol": "MMAC"
+    }
+  },
+  {
+    "name": "Summit / AVAX",
+    "token0": {
+      "id": "0x36343024549c63e9ac61d965bb2e5b6a4a209cc8",
+      "name": "Summit",
+      "symbol": "Summit"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "ROY / AVAX",
+    "token0": {
+      "id": "0x68ee0d0aad9e1984af85ca224117e4d20eaf68be",
+      "name": "Royale",
+      "symbol": "ROY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "LOST / AVAX",
+    "token0": {
+      "id": "0x449674b82f05d498e126dd6615a1057a9c088f2c",
+      "name": "LostToken",
+      "symbol": "LOST"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "ZEUS / AVAX",
+    "token0": {
+      "id": "0x8c3633ee619a42d3755327c2524e4d108838c47f",
+      "name": "Zeus Finance",
+      "symbol": "ZEUS"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "KALM / USDC",
+    "token0": {
+      "id": "0x62aceea3e666c5706ce1c61055fac1a669d31d93",
+      "name": "Kalmar Token",
+      "symbol": "KALM"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "KALM / AVAX",
+    "token0": {
+      "id": "0x62aceea3e666c5706ce1c61055fac1a669d31d93",
+      "name": "Kalmar Token",
+      "symbol": "KALM"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "QI / AVAX",
+    "token0": {
+      "id": "0x8729438eb15e2c8b576fcc6aecda6a148776c0f5",
+      "name": "BENQI",
+      "symbol": "QI"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "USDC / COSMIC",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xe48c74833ce6f18a8e54f73f1d02b8e9f9ff8caa",
+      "name": "Cosmic",
+      "symbol": "COSMIC"
+    }
+  },
+  {
+    "name": "ORBS / AVAX",
+    "token0": {
+      "id": "0x340fe1d898eccaad394e2ba0fc1f93d27c7b717a",
+      "name": "Orbs",
+      "symbol": "ORBS"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "PLEB / AVAX",
+    "token0": {
+      "id": "0x625fc9bb971bb305a2ad63252665dcfe9098bee9",
+      "name": "PlebToken",
+      "symbol": "PLEB"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "LEO / AVAX",
+    "token0": {
+      "id": "0x945a6869819cdad404dc80647a2085957cb1f28b",
+      "name": "Leonidas",
+      "symbol": "LEO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "YAK / AVAX",
+    "token0": {
+      "id": "0x59414b3089ce2af0010e7523dea7e2b35d776ec7",
+      "name": "Yak Token",
+      "symbol": "YAK"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "RBX / AVAX",
+    "token0": {
+      "id": "0x94960952876e3ed6a7760b198354fcc5319a406a",
+      "name": "RBX",
+      "symbol": "RBX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "LAYER / AVAX",
+    "token0": {
+      "id": "0x85272c4380b25e9047bc749d18c265550fd17017",
+      "name": "LayerFort",
+      "symbol": "LAYER"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "APE / AVAX",
+    "token0": {
+      "id": "0x0802d66f029c46e042b74d543fc43b6705ccb4ba",
+      "name": "ApeCoin",
+      "symbol": "APE"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FOOK / AVAX",
+    "token0": {
+      "id": "0x95923f63da09b4f7520f7c65a31f318d8228b744",
+      "name": "FOOK Token",
+      "symbol": "FOOK"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "JPEG / AVAX",
+    "token0": {
+      "id": "0x6241af3817db48a7f9e19fd9446d78e50936d275",
+      "name": "JPEG",
+      "symbol": "JPEG"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "EGG / USDC",
+    "token0": {
+      "id": "0xad4a51ace0ae87c7e08fc58566630a367caa2691",
+      "name": "Egg Token",
+      "symbol": "EGG"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "GM / AVAX",
+    "token0": {
+      "id": "0x0b53b5da7d0f275c31a6a182622bdf02474af253",
+      "name": "GhostMarket Token",
+      "symbol": "GM"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "PAE / AVAX",
+    "token0": {
+      "id": "0x9466ab927611725b9af76b9f31b2f879ff14233d",
+      "name": "Ripae",
+      "symbol": "PAE"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "LOCAL / USDC",
+    "token0": {
+      "id": "0xac42f172484f4de5f26959c612e23ddc206998ab",
+      "name": "Local Terra Token (Wormhole)",
+      "symbol": "LOCAL"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "USDC / AVABBC",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xe83ce6bfb580583bd6a62b4be7b34fc25f02910d",
+      "name": "Avalanche ABBC",
+      "symbol": "AVABBC"
+    }
+  },
+  {
+    "name": "AVAX / SSH",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xed0bcd401d46cb35ee391839ad16f5214c14fd50",
+      "name": "Starship Super Heavy",
+      "symbol": "SSH"
+    }
+  },
+  {
+    "name": "DAMO / AVAX",
+    "token0": {
+      "id": "0x32958a28d1641af1d4bdd790550fc0d8049dbd3a",
+      "name": "HAI DAMO",
+      "symbol": "DAMO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "HUSKY / AVAX",
+    "token0": {
+      "id": "0x65378b697853568da9ff8eab60c13e1ee9f4a654",
+      "name": "Husky",
+      "symbol": "HUSKY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "CheemsX / AVAX",
+    "token0": {
+      "id": "0x726573a7774317dd108accb2720ac9848581f01d",
+      "name": "CheemsX",
+      "symbol": "CheemsX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "RIBT / AVAX",
+    "token0": {
+      "id": "0x302abf007c2045f1bc0867a4b7abaae2152e0eb3",
+      "name": "Ribbit",
+      "symbol": "RIBT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DOUB / USDC",
+    "token0": {
+      "id": "0xb11877e59c3b59870e8a6f771a0c83d1ee3f60f8",
+      "name": "PIRATE DOUBLOON",
+      "symbol": "DOUB"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "YOLK / USDC",
+    "token0": {
+      "id": "0x078a87d9893b389b4004803f9aee13cfc973ed70",
+      "name": "YOLK TOKEN",
+      "symbol": "YOLK"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / EVB",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xebe2eae72d6eaa44a3bca32cfdf81d3a687917c2",
+      "name": "EVERBURN",
+      "symbol": "EVB"
+    }
+  },
+  {
+    "name": "AVAX / PEFI",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe896cdeaac9615145c0ca09c8cd5c25bced6384c",
+      "name": "PenguinToken",
+      "symbol": "PEFI"
+    }
+  },
+  {
+    "name": "POLAR / AVAX",
+    "token0": {
+      "id": "0x6c1c0319d8ddcb0ffe1a68c5b3829fd361587db4",
+      "name": "POLAR",
+      "symbol": "POLAR"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MILF / AVAX",
+    "token0": {
+      "id": "0x6619ee604439a57cd3997a8a4042851783871db4",
+      "name": "Metaverse Investment Legacy Fund",
+      "symbol": "MILF"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DON / AVAX",
+    "token0": {
+      "id": "0x1db749847c4abb991d8b6032102383e6bfd9b1c7",
+      "name": "Dogeon Token",
+      "symbol": "DON"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "STASH / AVAX",
+    "token0": {
+      "id": "0x536e911b8ba66c9a8697bf7d7b9924456abcc9e7",
+      "name": "Stash",
+      "symbol": "STASH"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / PERA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfda866cfece71f4c17b4a5e5f9a00ac08c72eadc",
+      "name": "Pera Finance",
+      "symbol": "PERA"
+    }
+  },
+  {
+    "name": "AVAX / BAVA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe19a1684873fab5fb694cfd06607100a632ff21c",
+      "name": "BavaToken",
+      "symbol": "BAVA"
+    }
+  },
+  {
+    "name": "BCDT / AVAX",
+    "token0": {
+      "id": "0xafb2780cbb58b2af27023eb2a0e60c8ca0eee9bb",
+      "name": "Blockchain Certified Data Token",
+      "symbol": "BCDT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BRN / AVAX",
+    "token0": {
+      "id": "0x9ccad19669259c1fbf13fda959400c871b3d0e00",
+      "name": "BurnIt",
+      "symbol": "BRN"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "WETH.e / NFD",
+    "token0": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    },
+    "token1": {
+      "id": "0xf1293574ee43950e7a8c9f1005ff097a9a713959",
+      "name": "Feisty Doge NFT",
+      "symbol": "NFD"
+    }
+  },
+  {
+    "name": "FLEX / AVAX",
+    "token0": {
+      "id": "0x1bbe1def0590790484f34fab4be0a2f32889dc52",
+      "name": "REFLEXOR",
+      "symbol": "FLEX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "OTO / AVAX",
+    "token0": {
+      "id": "0x3e5a9f09923936427ad6e487b24e23a862fcf6b7",
+      "name": "OTO Protocol",
+      "symbol": "OTO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
     "name": "AVAX / HOOF",
     "token0": {
       "id": "AVAX",
@@ -2597,6 +2454,1449 @@
       "id": "0xe0bb6fed446a2dbb27f84d3c27c4ed8ea7603366",
       "name": "Metaderby game token",
       "symbol": "HOOF"
+    }
+  },
+  {
+    "name": "PINT / USDC",
+    "token0": {
+      "id": "0x3af0eb8bcbd4c4c6e26e309c4e47af59bad5fc2f",
+      "name": "pub.finance",
+      "symbol": "PINT"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / FRM",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe5caef4af8780e59df925470b050fb23c43ca68c",
+      "name": "Ferrum Network Token",
+      "symbol": "FRM"
+    }
+  },
+  {
+    "name": "Acash / AVAX",
+    "token0": {
+      "id": "0x928722af2ab0478cb3fa131e008f10323e11b5e1",
+      "name": "Avatarcash",
+      "symbol": "Acash"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "IDM / AVAX",
+    "token0": {
+      "id": "0x942fefe6bf3a56f4adc100ce1c2da2d32da8712a",
+      "name": "IDM Token",
+      "symbol": "IDM"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / WXGEM",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfa113908f851e6357d8a20e2a18c22113d5755a9",
+      "name": "Wrapped Exchange Genesis Ethlas Medium",
+      "symbol": "WXGEM"
+    }
+  },
+  {
+    "name": "DAXE / USDT.e",
+    "token0": {
+      "id": "0x5106f787e8778a86d1928ed5ad0b0215dbfa00b8",
+      "name": "DAXE",
+      "symbol": "DAXE"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "HAT / AVAX",
+    "token0": {
+      "id": "0x82fe038ea4b50f9c957da326c412ebd73462077c",
+      "name": "Joe Hat Token",
+      "symbol": "HAT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BARN / AVAX",
+    "token0": {
+      "id": "0x5dd43c5c3e1917fe7548bde3b972690f2e26b61f",
+      "name": "Barn Holdings",
+      "symbol": "BARN"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "COOK / AVAX",
+    "token0": {
+      "id": "0x637afeff75ca669ff92e4570b14d6399a658902f",
+      "name": "Poly-Peg COOK",
+      "symbol": "COOK"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SUB / AVAX",
+    "token0": {
+      "id": "0xa0105d7fc6190598523f568001a71164341b0a22",
+      "name": "Subzero",
+      "symbol": "SUB"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / BIFI",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd6070ae98b8069de6b494332d1a1a81b6179d960",
+      "name": "beefy.finance",
+      "symbol": "BIFI"
+    }
+  },
+  {
+    "name": "AVAX / SNOB",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc38f41a296a4493ff429f1238e030924a1542e50",
+      "name": "Snowball",
+      "symbol": "SNOB"
+    }
+  },
+  {
+    "name": "AVAX / MCD",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfe0da90f3e8fc5e373c90d34e57f417a834ff177",
+      "name": "Multi Chain Dao",
+      "symbol": "MCD"
+    }
+  },
+  {
+    "name": "FXS / AVAX",
+    "token0": {
+      "id": "0x214db107654ff987ad859f34125307783fc8e387",
+      "name": "Frax Share",
+      "symbol": "FXS"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "USV / DAI.e",
+    "token0": {
+      "id": "0xb0a8e082e5f8d2a04e74372c1be47737d85a0e73",
+      "name": "Universal Store of Value",
+      "symbol": "USV"
+    },
+    "token1": {
+      "id": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "name": "Dai Stablecoin",
+      "symbol": "DAI.e"
+    }
+  },
+  {
+    "name": "MIM / MILK",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xe5c987f00ebdd4e9414de30c2a0ff61e34d7d860",
+      "name": "MILK",
+      "symbol": "MILK"
+    }
+  },
+  {
+    "name": "BLZZ / AVAX",
+    "token0": {
+      "id": "0x0f34919404a290e71fc6a510cb4a6acb8d764b24",
+      "name": "Blizz.Finance Protocol Token",
+      "symbol": "BLZZ"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "HRW / USDT.e",
+    "token0": {
+      "id": "0x66c00e4b114ce1302e31a8e97c31214148351bbd",
+      "name": "Horse Racing Winner",
+      "symbol": "HRW"
+    },
+    "token1": {
+      "id": "0xc7198437980c041c805a1edcba50c1ce5db95118",
+      "name": "Tether USD",
+      "symbol": "USDT.e"
+    }
+  },
+  {
+    "name": "FOOKZ / AVAX",
+    "token0": {
+      "id": "0x27301e48af707f950765d5570d7279a6e3e3bc5b",
+      "name": "FOOK Zero",
+      "symbol": "FOOKZ"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "OWL / AVAX",
+    "token0": {
+      "id": "0xab547a8dc764408ce9dea41bdf689aeeb349da12",
+      "name": "Owl Token",
+      "symbol": "OWL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / KACY",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xf32398dae246c5f672b52a54e9b413dffcae1a44",
+      "name": "Kassandra",
+      "symbol": "KACY"
+    }
+  },
+  {
+    "name": "BPT / AVAX",
+    "token0": {
+      "id": "0x1111111111182587795ef1098ac7da81a108c97a",
+      "name": "Bold Point Token",
+      "symbol": "BPT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAT / AVAX",
+    "token0": {
+      "id": "0x7086c48c997b8597a1692798155b4fcf2cee7f0f",
+      "name": "AVAT",
+      "symbol": "AVAT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "ETHP / AVAX",
+    "token0": {
+      "id": "0x0755fa2f4aa6311e1d7c19990416c86f17d16f86",
+      "name": "ETHP",
+      "symbol": "ETHP"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "WBTC.e / USDC",
+    "token0": {
+      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
+      "name": "Wrapped BTC",
+      "symbol": "WBTC.e"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "CRAFT / AVAX",
+    "token0": {
+      "id": "0x8ae8be25c23833e0a01aa200403e826f611f9cd2",
+      "name": "CRAFT",
+      "symbol": "CRAFT"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / OT-wMEMO-24FEB2022",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xb7e446ff1a2eeea8cd07331c7e06b0276d0b06b7",
+      "name": "OT Wrapped MEMO 24FEB2022",
+      "symbol": "OT-wMEMO-24FEB2022"
+    }
+  },
+  {
+    "name": "CRAB / MIM",
+    "token0": {
+      "id": "0x0c771c317ffbbfc0e5dbf4c3e5e67a0566fbff37",
+      "name": "Crabby",
+      "symbol": "CRAB"
+    },
+    "token1": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    }
+  },
+  {
+    "name": "MND / AVAX",
+    "token0": {
+      "id": "0x1cd2528522a17b6be63012fb63ae81f3e3e29d97",
+      "name": "Mind Music",
+      "symbol": "MND"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "USDC / MEAT",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xd3253beb9d8ae234e9f2b72a66df07cc75ac9e79",
+      "name": "Meat",
+      "symbol": "MEAT"
+    }
+  },
+  {
+    "name": "USDC / 420",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xf7dd4d8142c1fa34c64d8c22fcbba42208cc65eb",
+      "name": "Token 420",
+      "symbol": "420"
+    }
+  },
+  {
+    "name": "STOMB / AVAX",
+    "token0": {
+      "id": "0x9e6832d13b29d0b1c1c3465242681039b31c7a05",
+      "name": "Snowtomb Token",
+      "symbol": "STOMB"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "CRYPTO / AVAX",
+    "token0": {
+      "id": "0xa465745a0c31aede8d56519c87ea44d51ea643e7",
+      "name": "CryptoCoin",
+      "symbol": "CRYPTO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BLOOD / AVAX",
+    "token0": {
+      "id": "0x8e8148078f913a36c9d8c7fb2da8b479c77c6ba5",
+      "name": "BLOOD",
+      "symbol": "BLOOD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FTOMB / AVAX",
+    "token0": {
+      "id": "0x7dfce792c83f283ecfe7ea7ed308f9b891073540",
+      "name": "Frozentomb Token",
+      "symbol": "FTOMB"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "UST / AVAX",
+    "token0": {
+      "id": "0x260bbf5698121eb85e7a74f2e45e16ce762ebe11",
+      "name": "Axelar Wrapped UST",
+      "symbol": "UST"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "KDAO / AVAX",
+    "token0": {
+      "id": "0x29debf83eb8bc91ce9a13ac7e42d37e6e2abb480",
+      "name": "KDAO",
+      "symbol": "KDAO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BFC / AVAX",
+    "token0": {
+      "id": "0x2d5433e9d475c78542dbd0d16d7016b9aab99c1c",
+      "name": "Big Fund Capital DAO",
+      "symbol": "BFC"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / WETH.e",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    }
+  },
+  {
+    "name": "JEWEL / AVAX",
+    "token0": {
+      "id": "0x4f60a160d8c2dddaafe16fcc57566db84d674bd6",
+      "name": "Jewels",
+      "symbol": "JEWEL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BABYKRAKENS / AVAX",
+    "token0": {
+      "id": "0xa2df0dc89dfc39faee6cf13dfbf2203fea3670e4",
+      "name": "BABYKRAKENS",
+      "symbol": "BABYKRAKENS"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "KITTY / AVAX",
+    "token0": {
+      "id": "0x788ae3b5d153d49f8db649aacba1857f744b739e",
+      "name": "KITTY",
+      "symbol": "KITTY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / NEKO",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xfcafd21c47070085b2602b3d7e8e04493dcfad8b",
+      "name": "SnowNeko",
+      "symbol": "NEKO"
+    }
+  },
+  {
+    "name": "JNS / AVAX",
+    "token0": {
+      "id": "0x7a023a408f51c23760eb31190fc731bc12b52954",
+      "name": "Janus Network",
+      "symbol": "JNS"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "Pepper / AVAX",
+    "token0": {
+      "id": "0x576cdf9e8a1816b0aa5fa7ca63c41b18583a6335",
+      "name": "PepperPrint",
+      "symbol": "Pepper"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SafeMoonA / AVAX",
+    "token0": {
+      "id": "0x4501e37a79cf953116331a105b3644d07b74c0f8",
+      "name": "SafeMoonAvax",
+      "symbol": "SafeMoonA"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "STG / AVAX",
+    "token0": {
+      "id": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590",
+      "name": "StargateToken",
+      "symbol": "STG"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "USDt / USDC",
+    "token0": {
+      "id": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "name": "TetherToken",
+      "symbol": "USDt"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "ZOMBIE / AVAX",
+    "token0": {
+      "id": "0x431bdc9975d570da5ed69c4e97e27114bcd55a86",
+      "name": "zombie.finance",
+      "symbol": "ZOMBIE"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "PUGGY / AVAX",
+    "token0": {
+      "id": "0x553373bae3df6dfb1da1e34aafdad2e5f9a104b0",
+      "name": "Puggy",
+      "symbol": "PUGGY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / TOC",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xf2e4a7c6d028006a4fe65ba7ea308051d380fd9b",
+      "name": "Treasury of the City",
+      "symbol": "TOC"
+    }
+  },
+  {
+    "name": "USDC / MEAD",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xd21cdca47fa45a0a51eec030e27af390ab3aa489",
+      "name": "Mead",
+      "symbol": "MEAD"
+    }
+  },
+  {
+    "name": "MIM / GHOST",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xa72eab7327e48bde0ff873eaf1d4fecf6036504f",
+      "name": "Ghost",
+      "symbol": "GHOST"
+    }
+  },
+  {
+    "name": "OTO / AVAX",
+    "token0": {
+      "id": "0x0ac80e1753dea5e298e8a2b6cf53f161937806a1",
+      "name": "OTO V2",
+      "symbol": "OTO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AvSTRM / USDC",
+    "token0": {
+      "id": "0x94a7f270cd12545a277e656266aef5e27df3eb28",
+      "name": "Avalanche-Peg Stream",
+      "symbol": "AvSTRM"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVOGE / AVAX",
+    "token0": {
+      "id": "0x779595f212b53e4f1f51b0875405bf21b5e4d805",
+      "name": "Avoge",
+      "symbol": "AVOGE"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / ApeU",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x6b0d2a3c37d551963275bb104f045f6a68ab6374",
+      "name": "APE UNIVERSE",
+      "symbol": "ApeU"
+    }
+  },
+  {
+    "name": "MIM / SEA",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xb195af20a0fec7e2c95b22a1c5de86a2389e40d5",
+      "name": "Sea",
+      "symbol": "SEA"
+    }
+  },
+  {
+    "name": "MIM / SB",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x7d1232b90d3f809a54eeaeebc639c62df8a8942f",
+      "name": "Snowbank",
+      "symbol": "SB"
+    }
+  },
+  {
+    "name": "MIM / BEE",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x5b4192b5636f7b6ab6d963865963e92bbba5aac0",
+      "name": "BCoin",
+      "symbol": "BEE"
+    }
+  },
+  {
+    "name": "WETH.e / yyAVAX",
+    "token0": {
+      "id": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "name": "Wrapped Ether",
+      "symbol": "WETH.e"
+    },
+    "token1": {
+      "id": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+      "name": "YieldYak gAVAX",
+      "symbol": "yyAVAX"
+    }
+  },
+  {
+    "name": "CHILL / AVAX",
+    "token0": {
+      "id": "0x4d1365c746abb9e2d87216c06c18a5a1e9d2c298",
+      "name": "CHILL",
+      "symbol": "CHILL"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "BLIZZ / AVAX",
+    "token0": {
+      "id": "0xa2776a53da0bf664ea34b8efa1c8ab4241a10968",
+      "name": "Blizzard",
+      "symbol": "BLIZZ"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / BLANC",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xf481eec738c46f675e077ee966a680a19210af11",
+      "name": "Blanc",
+      "symbol": "BLANC"
+    }
+  },
+  {
+    "name": "USDC / MNode",
+    "token0": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    "token1": {
+      "id": "0xc468f872961200ecab30cff4e618e7dea8aedd4d",
+      "name": "MultiNode",
+      "symbol": "MNode"
+    }
+  },
+  {
+    "name": "SHIBX / AVAX",
+    "token0": {
+      "id": "0x440abbf18c54b2782a4917b80a1746d3a2c2cce1",
+      "name": "SHIBAVAX",
+      "symbol": "SHIBX"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAEARN / AVAX",
+    "token0": {
+      "id": "0x35b11ed72dd0d49f1833cb9791e04b3afd1300f8",
+      "name": "AVAEARN",
+      "symbol": "AVAEARN"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / MISTEL",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xf3f8772f92028bfb6d641c28bbcf1dbded424767",
+      "name": "Mistel Finance",
+      "symbol": "MISTEL"
+    }
+  },
+  {
+    "name": "AVAX / snoAVAX",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xda1d9c79240003195d0a67f202efcccc3f78b994",
+      "name": "SnowPEGS AVAX Peg",
+      "symbol": "snoAVAX"
+    }
+  },
+  {
+    "name": "PREZ / AVAX",
+    "token0": {
+      "id": "0x84f4df4d33be4c5f7f28fe8568fec987875434a8",
+      "name": "Santas Workshop",
+      "symbol": "PREZ"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "TRACTOR / AVAX",
+    "token0": {
+      "id": "0x542fa0b261503333b90fe60c78f2beed16b7b7fd",
+      "name": "TRACTOR JOE",
+      "symbol": "TRACTOR"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / 0xB",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd2ad73ce020911a4c04c284bfd2d451b4a777bdb",
+      "name": "0xBlock",
+      "symbol": "0xB"
+    }
+  },
+  {
+    "name": "AVAPAY / AVAX",
+    "token0": {
+      "id": "0x3f3fea5dd9b1940c2ee4822d7b7a06f19d58656e",
+      "name": "AVAPAY",
+      "symbol": "AVAPAY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "GRAVE / AVAX",
+    "token0": {
+      "id": "0x3700a92dd231f0cac37d31dbcf4c0f5ccb1db6ca",
+      "name": "grave.finance",
+      "symbol": "GRAVE"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "WTF / AVAX",
+    "token0": {
+      "id": "0x873801ae2ff12d816db9a7b082f5796bec64c82c",
+      "name": "Waterfall Governance Token",
+      "symbol": "WTF"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "GLAD / AVAX",
+    "token0": {
+      "id": "0xa7c43db4c0f6b59ec3ba65e256025721871aba7d",
+      "name": "Gladiator Finance",
+      "symbol": "GLAD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / ANTG",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xca1068444196cdfe676fd15a29f35e502580a69e",
+      "name": "AntGold",
+      "symbol": "ANTG"
+    }
+  },
+  {
+    "name": "AVAX / OSWAP",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb32ac3c79a94ac1eb258f3c830bbdbc676483c93",
+      "name": "OpenSwap",
+      "symbol": "OSWAP"
+    }
+  },
+  {
+    "name": "MAI / AVAX",
+    "token0": {
+      "id": "0x5c49b268c9841aff1cc3b0a418ff5c3442ee3f3b",
+      "name": "Mai Stablecoin",
+      "symbol": "MAI"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / WAGMI",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xcd024f038b6e79968f9aba4bee3e27cb3c9e1e91",
+      "name": "WAGMI",
+      "symbol": "WAGMI"
+    }
+  },
+  {
+    "name": "AVAX / ELK",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe1c110e1b1b4a1ded0caf3e42bfbdbb7b5d7ce1c",
+      "name": "Elk",
+      "symbol": "ELK"
+    }
+  },
+  {
+    "name": "SB / AVAX",
+    "token0": {
+      "id": "0x7d1232b90d3f809a54eeaeebc639c62df8a8942f",
+      "name": "Snowbank",
+      "symbol": "SB"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / SCOOBY",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc147ee445e9e7575d8200c0121ec4502f354bff4",
+      "name": "ScoobyDoo",
+      "symbol": "SCOOBY"
+    }
+  },
+  {
+    "name": "NFTART / AVAX",
+    "token0": {
+      "id": "0x74a488bccb16d90fd628e75132e49ff067384aa9",
+      "name": "NFTArt.Finance",
+      "symbol": "NFTART"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "ASTRO / AVAX",
+    "token0": {
+      "id": "0x6d2f5dbf3a7396fce32cfe406aef7a8aff812fbb",
+      "name": "100 Days Ventures - v1.1",
+      "symbol": "ASTRO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / PEDESTAL",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xb40b244a6f766eedc2b34bb610d2cf40b257d6dc",
+      "name": "Pedestal Node Finance",
+      "symbol": "PEDESTAL"
+    }
+  },
+  {
+    "name": "BVIC / WBTC.e",
+    "token0": {
+      "id": "0x3cd3d19ab5e88a07dbbc683ff0a7ed38e833fd3e",
+      "name": "Bitcoin Victory",
+      "symbol": "BVIC"
+    },
+    "token1": {
+      "id": "0x50b7545627a5162f82a992c33b87adc75187b218",
+      "name": "Wrapped BTC",
+      "symbol": "WBTC.e"
+    }
+  },
+  {
+    "name": "AVAX / AKITA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xcaf5191fc480f43e4df80106c7695eca56e48b18",
+      "name": "Akita Inu",
+      "symbol": "AKITA"
+    }
+  },
+  {
+    "name": "MIM / ARA",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0x2ced20fdfcbe72c27a607d0c9ab1c9ada598c60f",
+      "name": "Ara",
+      "symbol": "ARA"
+    }
+  },
+  {
+    "name": "WOOD / AVAX",
+    "token0": {
+      "id": "0xa886c732703700efcbd8438768822c8e716cb0ec",
+      "name": "Fief Wood",
+      "symbol": "WOOD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "HATCHY / AVAX",
+    "token0": {
+      "id": "0x502580fc390606b47fc3b741d6d49909383c28a9",
+      "name": "Hatchy",
+      "symbol": "HATCHY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "MIM / MONG",
+    "token0": {
+      "id": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "name": "Magic Internet Money",
+      "symbol": "MIM"
+    },
+    "token1": {
+      "id": "0xd74cca216f7c8fe33f0911da8698e2b3efc98835",
+      "name": "Mongoose",
+      "symbol": "MONG"
+    }
+  },
+  {
+    "name": "BUSD / USDC",
+    "token0": {
+      "id": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
+      "name": "BUSD Token",
+      "symbol": "BUSD"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / NEXT",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc0cd51030c03b8c5cbb76cb5efad72f126aa471f",
+      "name": "NEXT NODE",
+      "symbol": "NEXT"
+    }
+  },
+  {
+    "name": "KURAMA / AVAX",
+    "token0": {
+      "id": "0x4566c379d49779d4442c7e25c892164fedeec67c",
+      "name": "Kurama Inu",
+      "symbol": "KURAMA"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FROST / AVAX",
+    "token0": {
+      "id": "0x320ada89dbfa3a154613d2731c9bc3a4030dba19",
+      "name": "FROST",
+      "symbol": "FROST"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / ICY",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe18950c8f3b01f549cfc79dc44c3944fbd43fb76",
+      "name": "ICY.MONEY",
+      "symbol": "ICY"
+    }
+  },
+  {
+    "name": "SEED / AVAX",
+    "token0": {
+      "id": "0xa843f6b5039edd40dcea6a6c2c9a5b501470c8f2",
+      "name": "Seed",
+      "symbol": "SEED"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "FST / AVAX",
+    "token0": {
+      "id": "0x505421748269463fb51b320d12bc68831bbed959",
+      "name": "FutureSwap token",
+      "symbol": "FST"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "SUB / USDC",
+    "token0": {
+      "id": "0xa0105d7fc6190598523f568001a71164341b0a22",
+      "name": "Subzero",
+      "symbol": "SUB"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "CON / USDC",
+    "token0": {
+      "id": "0x1ed959d43696a045f7cf59748f04ce272922917f",
+      "name": "Contexia",
+      "symbol": "CON"
+    },
+    "token1": {
+      "id": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC"
+    }
+  },
+  {
+    "name": "AVAX / FIEF",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xea068fba19ce95f12d252ad8cb2939225c4ea02d",
+      "name": "Fief",
+      "symbol": "FIEF"
+    }
+  },
+  {
+    "name": "AVAX / Hedge Fund",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xe387cf241b6685d405c575ce35db78ed4844b34a",
+      "name": "Hedge Fund",
+      "symbol": "Hedge Fund"
+    }
+  },
+  {
+    "name": "YAY / AVAX",
+    "token0": {
+      "id": "0x01c2086facfd7aa38f69a6bd8c91bef3bb5adfca",
+      "name": "YAY Games",
+      "symbol": "YAY"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AFN / AVAX",
+    "token0": {
+      "id": "0x55ee1c67d787a2ce2cebf691c524f958520e1d1a",
+      "name": "AFFINITY ",
+      "symbol": "AFN"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "DWNBD / AVAX",
+    "token0": {
+      "id": "0x6293bd9d427ba0bfe40641f6fb9df061aea1e5bd",
+      "name": "DOWNBAD",
+      "symbol": "DWNBD"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / DSLA",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xd7c295e399ca928a3a14b01d760e794f1adf8990",
+      "name": "DSLA",
+      "symbol": "DSLA"
+    }
+  },
+  {
+    "name": "DINO / AVAX",
+    "token0": {
+      "id": "0x8d8db824bafdb617646e80360509274909c48127",
+      "name": "Dino",
+      "symbol": "DINO"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "NODEC / AVAX",
+    "token0": {
+      "id": "0x224db37f1745a2f5d49e06a204ad6a38ba827fa8",
+      "name": "Piler",
+      "symbol": "NODEC"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "PAPER / AVAX",
+    "token0": {
+      "id": "0x1affbc17938a25d245e1b7ec6f2fc949df8e9760",
+      "name": "PAPER",
+      "symbol": "PAPER"
+    },
+    "token1": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "name": "AVAX / EMRLD",
+    "token0": {
+      "id": "AVAX",
+      "name": "AVAX",
+      "symbol": "AVAX"
+    },
+    "token1": {
+      "id": "0xc50eb6c984e172f69ec5b219d815622c39eb01be",
+      "name": "Emerald Protocol V2",
+      "symbol": "EMRLD"
     }
   }
 ]


### PR DESCRIPTION
In this PR, I updated markets data using the following graphql query:
```
pairs(
  first: 300
  orderBy: reserveUSD
  orderDirection: desc
  where: { volumeUSD_gt: 1 }
) {
  name
  token0 {
    id
    name
    symbol
  }
  token1 {
    id
    name
    symbol
  }
}
```