### PR TITLE
add CheckDot CDT token info

### DIFF
--- a/mc.tokenlist.json
+++ b/mc.tokenlist.json
@@ -1492,6 +1492,15 @@
       "symbol": "INFRA.e",
       "tags": ["DeFi"],
       "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xa4FB4F0Ff2431262D236778495145EcBC975c38B/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x0cBD6fAdcF8096cC9A43d90B45F65826102e3eCE",
+      "decimals": 18,
+      "name": "CheckDot",
+      "symbol": "CDT",
+      "tags": ["DeFi"],
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x0cBD6fAdcF8096cC9A43d90B45F65826102e3eCE/logo.png"
     }
   ],
   "timestamp": "2021-05-15T00:00:00+00:00"


### PR DESCRIPTION
Last logo PR https://github.com/traderjoe-xyz/joe-tokenlists/pull/811

Name: CheckDot
Symbol: CDT
Decimals: 18
Website: https://checkdot.io/
CoinGecko: https://www.coingecko.com/en/coins/checkdot
CoinMarketCap: https://coinmarketcap.com/currencies/checkdot
Token Address: 0x0cBD6fAdcF8096cC9A43d90B45F65826102e3eCE
TrustWallet Approved: https://github.com/trustwallet/assets/pull/22420
Audit Token Contract: https://github.com/Quillhash/QuillAudit_Reports/blob/master/Checkdot%20Smart%20Contract%20Audit%20Report%20-%20QuillAudits.pdf
KYC Team: https://github.com/solidproof/kyc-certificates/blob/main/KYC_Certificate_Checkdot.png , https://github.com/flooz-link/flooz-kyc-verification/blob/main/KYC/bsc-0x0cbd6fadcf8096cc9a43d90b45f65826102e3ece.png